### PR TITLE
[mock_tests]: Add CoPP Orch UTs

### DIFF
--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -26,6 +26,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 routeorch_ut.cpp \
                 qosorch_ut.cpp \
                 bufferorch_ut.cpp \
+                copporch_ut.cpp \
                 saispy_ut.cpp \
                 consumer_ut.cpp \
                 ut_saihelper.cpp \

--- a/tests/mock_tests/copporch_ut.cpp
+++ b/tests/mock_tests/copporch_ut.cpp
@@ -1,0 +1,501 @@
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+
+using namespace swss;
+
+namespace copporch_test
+{
+    class MockCoppOrch final
+    {
+    public:
+        MockCoppOrch()
+        {
+            this->appDb = std::make_shared<DBConnector>("APPL_DB", 0);
+            this->coppOrch = std::make_shared<CoppOrch>(this->appDb.get(), APP_COPP_TABLE_NAME);
+        }
+        ~MockCoppOrch() = default;
+
+        void doCoppTableTask(const std::deque<KeyOpFieldsValuesTuple> &entries)
+        {
+            // ConsumerStateTable is used for APP DB
+            auto consumer = std::unique_ptr<Consumer>(new Consumer(
+                new ConsumerStateTable(this->appDb.get(), APP_COPP_TABLE_NAME, 1, 1),
+                this->coppOrch.get(), APP_COPP_TABLE_NAME
+            ));
+
+            consumer->addToSync(entries);
+            static_cast<Orch*>(this->coppOrch.get())->doTask(*consumer);
+        }
+
+        CoppOrch& get()
+        {
+            return *coppOrch;
+        }
+
+    private:
+        std::shared_ptr<CoppOrch> coppOrch;
+        std::shared_ptr<DBConnector> appDb;
+    };
+
+    class CoppOrchTest : public ::testing::Test
+    {
+    public:
+        CoppOrchTest()
+        {
+            this->initDb();
+        }
+        virtual ~CoppOrchTest() = default;
+
+        void SetUp() override
+        {
+            this->initSaiApi();
+            this->initSwitch();
+            this->initOrch();
+            this->initPorts();
+        }
+
+        void TearDown() override
+        {
+            this->deinitOrch();
+            this->deinitSwitch();
+            this->deinitSaiApi();
+        }
+
+    private:
+        void initSaiApi()
+        {
+            std::map<std::string, std::string> profileMap = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00"        }
+            };
+            auto status = ut_helper::initSaiApi(profileMap);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+        }
+
+        void deinitSaiApi()
+        {
+            auto status = ut_helper::uninitSaiApi();
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+        }
+
+        void initSwitch()
+        {
+            sai_status_t status;
+            sai_attribute_t attr;
+
+            // Create switch
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+
+            status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            // Get switch source MAC address
+            attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gMacAddress = attr.value.mac;
+
+            // Get switch default virtual router ID
+            attr.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gVirtualRouterId = attr.value.oid;
+        }
+
+        void deinitSwitch()
+        {
+            // Remove switch
+            auto status = sai_switch_api->remove_switch(gSwitchId);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gSwitchId = SAI_NULL_OBJECT_ID;
+            gVirtualRouterId = SAI_NULL_OBJECT_ID;
+        }
+
+        void initOrch()
+        {
+            //
+            // SwitchOrch
+            //
+
+            TableConnector switchCapTableStateDb(this->stateDb.get(), "SWITCH_CAPABILITY");
+            TableConnector asicSensorsTableCfgDb(this->configDb.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+            TableConnector switchTableAppDb(this->appDb.get(), APP_SWITCH_TABLE_NAME);
+
+            std::vector<TableConnector> switchTableList = {
+                asicSensorsTableCfgDb,
+                switchTableAppDb
+            };
+
+            gSwitchOrch = new SwitchOrch(this->appDb.get(), switchTableList, switchCapTableStateDb);
+            gDirectory.set(gSwitchOrch);
+            resourcesList.push_back(gSwitchOrch);
+
+            //
+            // PortsOrch
+            //
+
+            const int portsorchBasePri = 40;
+
+            std::vector<table_name_with_pri_t> portTableList = {
+                { APP_PORT_TABLE_NAME,        portsorchBasePri + 5 },
+                { APP_VLAN_TABLE_NAME,        portsorchBasePri + 2 },
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorchBasePri     },
+                { APP_LAG_TABLE_NAME,         portsorchBasePri + 4 },
+                { APP_LAG_MEMBER_TABLE_NAME,  portsorchBasePri     }
+            };
+
+            gPortsOrch = new PortsOrch(this->appDb.get(), this->stateDb.get(), portTableList, this->chassisAppDb.get());
+            gDirectory.set(gPortsOrch);
+            resourcesList.push_back(gPortsOrch);
+
+            //
+            // QosOrch
+            //
+
+            std::vector<std::string> qosTableList = {
+                CFG_TC_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_SCHEDULER_TABLE_NAME,
+                CFG_DSCP_TO_TC_MAP_TABLE_NAME,
+                CFG_MPLS_TC_TO_TC_MAP_TABLE_NAME,
+                CFG_DOT1P_TO_TC_MAP_TABLE_NAME,
+                CFG_QUEUE_TABLE_NAME,
+                CFG_PORT_QOS_MAP_TABLE_NAME,
+                CFG_WRED_PROFILE_TABLE_NAME,
+                CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_DSCP_TO_FC_MAP_TABLE_NAME,
+                CFG_EXP_TO_FC_MAP_TABLE_NAME
+            };
+            gQosOrch = new QosOrch(this->configDb.get(), qosTableList);
+            gDirectory.set(gQosOrch);
+            resourcesList.push_back(gQosOrch);
+
+            //
+            // BufferOrch
+            //
+
+            std::vector<std::string> bufferTableList = {
+                APP_BUFFER_POOL_TABLE_NAME,
+                APP_BUFFER_PROFILE_TABLE_NAME,
+                APP_BUFFER_QUEUE_TABLE_NAME,
+                APP_BUFFER_PG_TABLE_NAME,
+                APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
+            };
+            gBufferOrch = new BufferOrch(this->appDb.get(), this->configDb.get(), this->stateDb.get(), bufferTableList);
+            gDirectory.set(gBufferOrch);
+            resourcesList.push_back(gBufferOrch);
+
+            //
+            // PolicerOrch
+            //
+
+            auto policerOrch = new PolicerOrch(this->configDb.get(), CFG_POLICER_TABLE_NAME);
+            gDirectory.set(policerOrch);
+            resourcesList.push_back(policerOrch);
+
+            //
+            // FlexCounterOrch
+            //
+
+            std::vector<std::string> flexCounterTableList = {
+                CFG_FLEX_COUNTER_TABLE_NAME
+            };
+
+            auto flexCounterOrch = new FlexCounterOrch(this->configDb.get(), flexCounterTableList);
+            gDirectory.set(flexCounterOrch);
+            resourcesList.push_back(flexCounterOrch);
+        }
+
+        void deinitOrch()
+        {
+            std::reverse(this->resourcesList.begin(), this->resourcesList.end());
+            for (auto &it : this->resourcesList)
+            {
+                delete it;
+            }
+
+            gSwitchOrch = nullptr;
+            gPortsOrch = nullptr;
+            gQosOrch = nullptr;
+            gBufferOrch = nullptr;
+
+            Portal::DirectoryInternal::clear(gDirectory);
+            EXPECT_TRUE(Portal::DirectoryInternal::empty(gDirectory));
+        }
+
+        void initPorts()
+        {
+            auto portTable = Table(this->appDb.get(), APP_PORT_TABLE_NAME);
+
+            // Get SAI default ports to populate DB
+            auto ports = ut_helper::getInitialSaiPorts();
+
+            // Populate port table with SAI ports
+            for (const auto &cit : ports)
+            {
+                portTable.set(cit.first, cit.second);
+            }
+
+            // Set PortConfigDone
+            portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch*>(gPortsOrch)->doTask();
+
+            // Set PortInitDone
+            portTable.set("PortInitDone", { { "lanes", "0" } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch*>(gPortsOrch)->doTask();
+        }
+
+        void initDb()
+        {
+            this->appDb = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            this->configDb = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            this->stateDb = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+            this->chassisAppDb = std::make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
+        }
+
+        std::shared_ptr<DBConnector> appDb;
+        std::shared_ptr<DBConnector> configDb;
+        std::shared_ptr<DBConnector> stateDb;
+        std::shared_ptr<DBConnector> chassisAppDb;
+
+        std::vector<Orch*> resourcesList;
+    };
+
+    TEST_F(CoppOrchTest, TrapGroup_AddRemove)
+    {
+        const std::string trapGroupName = "queue4_group1";
+
+        MockCoppOrch coppOrch;
+
+        // Create CoPP Trap Group
+        {
+            auto tableKofvt = std::deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        trapGroupName,
+                        SET_COMMAND,
+                        {
+                            { copp_trap_action_field,   "trap" },
+                            { copp_trap_priority_field, "4"    },
+                            { copp_queue_field,         "4"    }
+                        }
+                    }
+                }
+            );
+            coppOrch.doCoppTableTask(tableKofvt);
+
+            const auto &trapGroupMap = coppOrch.get().getTrapGroupMap();
+            const auto &cit = trapGroupMap.find(trapGroupName);
+            EXPECT_TRUE(cit != trapGroupMap.end());
+        }
+
+        // Delete CoPP Trap Group
+        {
+            auto tableKofvt = std::deque<KeyOpFieldsValuesTuple>(
+                { { trapGroupName, DEL_COMMAND, { } } }
+            );
+            coppOrch.doCoppTableTask(tableKofvt);
+
+            const auto &trapGroupMap = coppOrch.get().getTrapGroupMap();
+            const auto &cit = trapGroupMap.find(trapGroupName);
+            EXPECT_TRUE(cit == trapGroupMap.end());
+        }
+    }
+
+    TEST_F(CoppOrchTest, TrapGroupWithPolicer_AddRemove)
+    {
+        const std::string trapGroupName = "queue4_group2";
+
+        MockCoppOrch coppOrch;
+
+        // Create CoPP Trap Group
+        {
+            auto tableKofvt = std::deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        trapGroupName,
+                        SET_COMMAND,
+                        {
+                            { copp_trap_action_field,        "copy"    },
+                            { copp_trap_priority_field,      "4"       },
+                            { copp_queue_field,              "4"       },
+                            { copp_policer_meter_type_field, "packets" },
+                            { copp_policer_mode_field,       "sr_tcm"  },
+                            { copp_policer_cir_field,        "600"     },
+                            { copp_policer_cbs_field,        "600"     },
+                            { copp_policer_action_red_field, "drop"    }
+                        }
+                    }
+                }
+            );
+            coppOrch.doCoppTableTask(tableKofvt);
+
+            const auto &trapGroupMap = coppOrch.get().getTrapGroupMap();
+            const auto &cit1 = trapGroupMap.find(trapGroupName);
+            EXPECT_TRUE(cit1 != trapGroupMap.end());
+
+            const auto &trapGroupPolicerMap = Portal::CoppOrchInternal::getTrapGroupPolicerMap(coppOrch.get());
+            const auto &trapGroupOid = cit1->second;
+            const auto &cit2 = trapGroupPolicerMap.find(trapGroupOid);
+            EXPECT_TRUE(cit2 != trapGroupPolicerMap.end());
+        }
+
+        // Delete CoPP Trap Group
+        {
+            auto tableKofvt = std::deque<KeyOpFieldsValuesTuple>(
+                { { trapGroupName, DEL_COMMAND, { } } }
+            );
+            coppOrch.doCoppTableTask(tableKofvt);
+
+            const auto &trapGroupMap = coppOrch.get().getTrapGroupMap();
+            const auto &cit = trapGroupMap.find(trapGroupName);
+            EXPECT_TRUE(cit == trapGroupMap.end());
+
+            const auto &trapGroupPolicerMap = Portal::CoppOrchInternal::getTrapGroupPolicerMap(coppOrch.get());
+            EXPECT_TRUE(trapGroupPolicerMap.empty());
+        }
+    }
+
+    TEST_F(CoppOrchTest, Trap_AddRemove)
+    {
+        const std::string trapGroupName = "queue4_group1";
+        const std::string trapNameList = "bgp,bgpv6";
+        const std::set<sai_hostif_trap_type_t> trapIDSet = {
+            SAI_HOSTIF_TRAP_TYPE_BGP,
+            SAI_HOSTIF_TRAP_TYPE_BGPV6
+        };
+
+        MockCoppOrch coppOrch;
+
+        // Create CoPP Trap
+        {
+            auto tableKofvt = std::deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        trapGroupName,
+                        SET_COMMAND,
+                        {
+                            { copp_trap_action_field,   "trap"       },
+                            { copp_trap_priority_field, "4"          },
+                            { copp_queue_field,         "4"          },
+                            { copp_trap_id_list,        trapNameList }
+                        }
+                    }
+                }
+            );
+            coppOrch.doCoppTableTask(tableKofvt);
+
+            const auto &trapGroupMap = coppOrch.get().getTrapGroupMap();
+            const auto &cit = trapGroupMap.find(trapGroupName);
+            EXPECT_TRUE(cit != trapGroupMap.end());
+
+            const auto &tgOid = cit->second;
+            const auto &tidList = Portal::CoppOrchInternal::getTrapIdsFromTrapGroup(coppOrch.get(), tgOid);
+            const auto &tidSet = std::set<sai_hostif_trap_type_t>(tidList.begin(), tidList.end());
+            EXPECT_TRUE(trapIDSet == tidSet);
+        }
+
+        // Delete CoPP Trap
+        {
+            auto tableKofvt = std::deque<KeyOpFieldsValuesTuple>(
+                { { trapGroupName, DEL_COMMAND, { } } }
+            );
+            coppOrch.doCoppTableTask(tableKofvt);
+
+            const auto &trapGroupMap = coppOrch.get().getTrapGroupMap();
+            const auto &cit1 = trapGroupMap.find(trapGroupName);
+            EXPECT_TRUE(cit1 == trapGroupMap.end());
+
+            const auto &trapGroupIdMap = Portal::CoppOrchInternal::getTrapGroupIdMap(coppOrch.get());
+            const auto &cit2 = trapGroupIdMap.find(SAI_HOSTIF_TRAP_TYPE_TTL_ERROR);
+            EXPECT_TRUE(cit2 != trapGroupIdMap.end());
+            ASSERT_EQ(trapGroupIdMap.size(), 1);
+        }
+    }
+
+    TEST_F(CoppOrchTest, TrapWithPolicer_AddRemove)
+    {
+        const std::string trapGroupName = "queue4_group2";
+        const std::string trapNameList = "arp_req,arp_resp,neigh_discovery";
+        const std::set<sai_hostif_trap_type_t> trapIDSet = {
+            SAI_HOSTIF_TRAP_TYPE_ARP_REQUEST,
+            SAI_HOSTIF_TRAP_TYPE_ARP_RESPONSE,
+            SAI_HOSTIF_TRAP_TYPE_IPV6_NEIGHBOR_DISCOVERY
+        };
+
+        MockCoppOrch coppOrch;
+
+        // Create CoPP Trap
+        {
+            auto tableKofvt = std::deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        trapGroupName,
+                        SET_COMMAND,
+                        {
+                            { copp_trap_action_field,        "copy"       },
+                            { copp_trap_priority_field,      "4"          },
+                            { copp_queue_field,              "4"          },
+                            { copp_policer_meter_type_field, "packets"    },
+                            { copp_policer_mode_field,       "sr_tcm"     },
+                            { copp_policer_cir_field,        "600"        },
+                            { copp_policer_cbs_field,        "600"        },
+                            { copp_policer_action_red_field, "drop"       },
+                            { copp_trap_id_list,             trapNameList }
+                        }
+                    }
+                }
+            );
+            coppOrch.doCoppTableTask(tableKofvt);
+
+            const auto &trapGroupMap = coppOrch.get().getTrapGroupMap();
+            const auto &cit1 = trapGroupMap.find(trapGroupName);
+            EXPECT_TRUE(cit1 != trapGroupMap.end());
+
+            const auto &trapGroupPolicerMap = Portal::CoppOrchInternal::getTrapGroupPolicerMap(coppOrch.get());
+            const auto &trapGroupOid = cit1->second;
+            const auto &cit2 = trapGroupPolicerMap.find(trapGroupOid);
+            EXPECT_TRUE(cit2 != trapGroupPolicerMap.end());
+
+            const auto &tidList = Portal::CoppOrchInternal::getTrapIdsFromTrapGroup(coppOrch.get(), trapGroupOid);
+            const auto &tidSet = std::set<sai_hostif_trap_type_t>(tidList.begin(), tidList.end());
+            EXPECT_TRUE(trapIDSet == tidSet);
+        }
+
+        // Delete CoPP Trap
+        {
+            auto tableKofvt = std::deque<KeyOpFieldsValuesTuple>(
+                { { trapGroupName, DEL_COMMAND, { } } }
+            );
+            coppOrch.doCoppTableTask(tableKofvt);
+
+            const auto &trapGroupMap = coppOrch.get().getTrapGroupMap();
+            const auto &cit1 = trapGroupMap.find(trapGroupName);
+            EXPECT_TRUE(cit1 == trapGroupMap.end());
+
+            const auto &trapGroupPolicerMap = Portal::CoppOrchInternal::getTrapGroupPolicerMap(coppOrch.get());
+            EXPECT_TRUE(trapGroupPolicerMap.empty());
+
+            const auto &trapGroupIdMap = Portal::CoppOrchInternal::getTrapGroupIdMap(coppOrch.get());
+            const auto &cit2 = trapGroupIdMap.find(SAI_HOSTIF_TRAP_TYPE_TTL_ERROR);
+            EXPECT_TRUE(cit2 != trapGroupIdMap.end());
+            ASSERT_EQ(trapGroupIdMap.size(), 1);
+        }
+    }
+}

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -23,6 +23,7 @@
 #include "tunneldecaporch.h"
 #include "muxorch.h"
 #include "nhgorch.h"
+#include "copporch.h"
 #include "directory.h"
 
 extern int gBatchSize;
@@ -70,6 +71,7 @@ extern sai_neighbor_api_t *sai_neighbor_api;
 extern sai_tunnel_api_t *sai_tunnel_api;
 extern sai_next_hop_api_t *sai_next_hop_api;
 extern sai_hostif_api_t *sai_hostif_api;
+extern sai_policer_api_t *sai_policer_api;
 extern sai_buffer_api_t *sai_buffer_api;
 extern sai_qos_map_api_t *sai_qos_map_api;
 extern sai_scheduler_api_t *sai_scheduler_api;

--- a/tests/mock_tests/portal.h
+++ b/tests/mock_tests/portal.h
@@ -5,6 +5,8 @@
 
 #include "aclorch.h"
 #include "crmorch.h"
+#include "copporch.h"
+#include "directory.h"
 
 #undef protected
 #undef private
@@ -57,6 +59,41 @@ struct Portal
         static void getResAvailableCounters(CrmOrch *crmOrch)
         {
             crmOrch->getResAvailableCounters();
+        }
+    };
+
+    struct CoppOrchInternal
+    {
+        static TrapGroupPolicerTable getTrapGroupPolicerMap(CoppOrch &obj)
+        {
+            return obj.m_trap_group_policer_map;
+        }
+
+        static TrapIdTrapObjectsTable getTrapGroupIdMap(CoppOrch &obj)
+        {
+            return obj.m_syncdTrapIds;
+        }
+
+        static std::vector<sai_hostif_trap_type_t> getTrapIdsFromTrapGroup(CoppOrch &obj, sai_object_id_t trapGroupOid)
+        {
+            std::vector<sai_hostif_trap_type_t> trapIdList;
+            obj.getTrapIdsFromTrapGroup(trapGroupOid, trapIdList);
+            return trapIdList;
+        }
+    };
+
+    struct DirectoryInternal
+    {
+        template <typename T>
+        static void clear(Directory<T> &obj)
+        {
+            obj.m_values.clear();
+        }
+
+        template <typename T>
+        static bool empty(Directory<T> &obj)
+        {
+            return obj.m_values.empty();
         }
     };
 };

--- a/tests/mock_tests/ut_helper.h
+++ b/tests/mock_tests/ut_helper.h
@@ -13,7 +13,7 @@
 namespace ut_helper
 {
     sai_status_t initSaiApi(const std::map<std::string, std::string> &profile);
-    void uninitSaiApi();
+    sai_status_t uninitSaiApi();
 
     map<string, vector<FieldValueTuple>> getInitialSaiPorts();
 }

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -76,6 +76,7 @@ namespace ut_helper
         sai_api_query(SAI_API_NEXT_HOP, (void **)&sai_next_hop_api);
         sai_api_query(SAI_API_ACL, (void **)&sai_acl_api);
         sai_api_query(SAI_API_HOSTIF, (void **)&sai_hostif_api);
+        sai_api_query(SAI_API_POLICER, (void **)&sai_policer_api);
         sai_api_query(SAI_API_BUFFER, (void **)&sai_buffer_api);
         sai_api_query(SAI_API_QOS_MAP, (void **)&sai_qos_map_api);
         sai_api_query(SAI_API_SCHEDULER_GROUP, (void **)&sai_scheduler_group_api);
@@ -87,9 +88,13 @@ namespace ut_helper
         return SAI_STATUS_SUCCESS;
     }
 
-    void uninitSaiApi()
+    sai_status_t uninitSaiApi()
     {
-        sai_api_uninitialize();
+        auto status = sai_api_uninitialize();
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            return status;
+        }
 
         sai_switch_api = nullptr;
         sai_bridge_api = nullptr;
@@ -104,8 +109,11 @@ namespace ut_helper
         sai_next_hop_api = nullptr;
         sai_acl_api = nullptr;
         sai_hostif_api = nullptr;
+        sai_policer_api = nullptr;
         sai_buffer_api = nullptr;
         sai_queue_api = nullptr;
+
+        return SAI_STATUS_SUCCESS;
     }
 
     map<string, vector<FieldValueTuple>> getInitialSaiPorts()


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

```
nazariig@ea93ee7576e4:/sonic/src/sonic-swss/tests/mock_tests$ ./tests --gtest_filter=CoppOrchTest*
Running main() from /build/googletest-YnT0O3/googletest-1.10.0.20201025/googletest/src/gtest_main.cc
Note: Google Test filter = CoppOrchTest*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from CoppOrchTest
[ RUN      ] CoppOrchTest.TrapGroup_AddRemove
[       OK ] CoppOrchTest.TrapGroup_AddRemove (76 ms)
[ RUN      ] CoppOrchTest.TrapGroupWithPolicer_AddRemove
[       OK ] CoppOrchTest.TrapGroupWithPolicer_AddRemove (77 ms)
[ RUN      ] CoppOrchTest.Trap_AddRemove
[       OK ] CoppOrchTest.Trap_AddRemove (74 ms)
[ RUN      ] CoppOrchTest.TrapWithPolicer_AddRemove
[       OK ] CoppOrchTest.TrapWithPolicer_AddRemove (74 ms)
[----------] 4 tests from CoppOrchTest (301 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (301 ms total)
[  PASSED  ] 4 tests.
```

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
```
nazariig@ea93ee7576e4:/sonic/src/sonic-swss/tests/mock_tests$ ./tests
Running main() from /build/googletest-YnT0O3/googletest-1.10.0.20201025/googletest/src/gtest_main.cc
[==========] Running 50 tests from 11 test suites.
[----------] Global test environment set-up.
[----------] 1 test from AclTest
[ RUN      ] AclTest.Create_L3_Acl_Table
[       OK ] AclTest.Create_L3_Acl_Table (0 ms)
[----------] 1 test from AclTest (0 ms total)

[----------] 8 tests from AclOrchTest
[ RUN      ] AclOrchTest.ACL_Creation_and_Destruction
[       OK ] AclOrchTest.ACL_Creation_and_Destruction (31 ms)
[ RUN      ] AclOrchTest.L3Acl_Matches_Actions
[       OK ] AclOrchTest.L3Acl_Matches_Actions (30 ms)
[ RUN      ] AclOrchTest.L3V6Acl_Matches_Actions
[       OK ] AclOrchTest.L3V6Acl_Matches_Actions (33 ms)
[ RUN      ] AclOrchTest.AclRule_Counter_Configuration
[       OK ] AclOrchTest.AclRule_Counter_Configuration (30 ms)
[ RUN      ] AclOrchTest.AclTableType_Configuration
[       OK ] AclOrchTest.AclTableType_Configuration (31 ms)
[ RUN      ] AclOrchTest.AclTableType_ActionValidation
[       OK ] AclOrchTest.AclTableType_ActionValidation (30 ms)
[ RUN      ] AclOrchTest.AclRuleUpdate
[       OK ] AclOrchTest.AclRuleUpdate (31 ms)
[ RUN      ] AclOrchTest.deleteNonExistingRule
[       OK ] AclOrchTest.deleteNonExistingRule (47 ms)
[----------] 8 tests from AclOrchTest (263 ms total)

[----------] 7 tests from PortsOrchTest
[ RUN      ] PortsOrchTest.PortReadinessColdBoot
[       OK ] PortsOrchTest.PortReadinessColdBoot (22 ms)
[ RUN      ] PortsOrchTest.PortReadinessWarmBoot
[       OK ] PortsOrchTest.PortReadinessWarmBoot (16 ms)
[ RUN      ] PortsOrchTest.PfcZeroBufferHandlerLocksPortPgAndQueue
[       OK ] PortsOrchTest.PfcZeroBufferHandlerLocksPortPgAndQueue (19 ms)
[ RUN      ] PortsOrchTest.PfcZeroBufferHandlerLocksPortWithZeroPoolCreated
[       OK ] PortsOrchTest.PfcZeroBufferHandlerLocksPortWithZeroPoolCreated (19 ms)
[ RUN      ] PortsOrchTest.LagMemberDoesNotCallSAIApiWhenPortIsAlreadyALagMember
[       OK ] PortsOrchTest.LagMemberDoesNotCallSAIApiWhenPortIsAlreadyALagMember (14 ms)
[ RUN      ] PortsOrchTest.PortOperStatusIsUpAndOperSpeedIsZero
[       OK ] PortsOrchTest.PortOperStatusIsUpAndOperSpeedIsZero (13 ms)
[ RUN      ] PortsOrchTest.LagMemberIsCreatedBeforeOtherObjectsAreCreatedOnLag
[       OK ] PortsOrchTest.LagMemberIsCreatedBeforeOtherObjectsAreCreatedOnLag (11 ms)
[----------] 7 tests from PortsOrchTest (114 ms total)

[----------] 3 tests from RouteOrchTest
[ RUN      ] RouteOrchTest.RouteOrchTestDelSetSameNexthop
[       OK ] RouteOrchTest.RouteOrchTestDelSetSameNexthop (47 ms)
[ RUN      ] RouteOrchTest.RouteOrchTestDelSetDiffNexthop
[       OK ] RouteOrchTest.RouteOrchTestDelSetDiffNexthop (46 ms)
[ RUN      ] RouteOrchTest.RouteOrchTestDelSetDefaultRoute
[       OK ] RouteOrchTest.RouteOrchTestDelSetDefaultRoute (45 ms)
[----------] 3 tests from RouteOrchTest (138 ms total)

[----------] 9 tests from QosOrchTest
[ RUN      ] QosOrchTest.QosOrchTestPortQosMapRemoveOneField
[       OK ] QosOrchTest.QosOrchTestPortQosMapRemoveOneField (46 ms)
[ RUN      ] QosOrchTest.QosOrchTestQueueRemoveWredProfile
[       OK ] QosOrchTest.QosOrchTestQueueRemoveWredProfile (46 ms)
[ RUN      ] QosOrchTest.QosOrchTestQueueRemoveScheduler
[       OK ] QosOrchTest.QosOrchTestQueueRemoveScheduler (83 ms)
[ RUN      ] QosOrchTest.QosOrchTestQueueReplaceFieldAndRemoveObject
[       OK ] QosOrchTest.QosOrchTestQueueReplaceFieldAndRemoveObject (48 ms)
[ RUN      ] QosOrchTest.QosOrchTestPortQosMapReplaceOneFieldAndRemoveObject
[       OK ] QosOrchTest.QosOrchTestPortQosMapReplaceOneFieldAndRemoveObject (47 ms)
[ RUN      ] QosOrchTest.QosOrchTestPortQosMapReferencingObjRemoveThenAdd
[       OK ] QosOrchTest.QosOrchTestPortQosMapReferencingObjRemoveThenAdd (47 ms)
[ RUN      ] QosOrchTest.QosOrchTestQueueReferencingObjRemoveThenAdd
[       OK ] QosOrchTest.QosOrchTestQueueReferencingObjRemoveThenAdd (46 ms)
[ RUN      ] QosOrchTest.QosOrchTestGlobalDscpToTcMap
[       OK ] QosOrchTest.QosOrchTestGlobalDscpToTcMap (47 ms)
[ RUN      ] QosOrchTest.QosOrchTestRetryFirstItem
[       OK ] QosOrchTest.QosOrchTestRetryFirstItem (46 ms)
[----------] 9 tests from QosOrchTest (457 ms total)

[----------] 2 tests from BufferOrchTest
[ RUN      ] BufferOrchTest.BufferOrchTestBufferPgReferencingObjRemoveThenAdd
[       OK ] BufferOrchTest.BufferOrchTestBufferPgReferencingObjRemoveThenAdd (48 ms)
[ RUN      ] BufferOrchTest.BufferOrchTestReferencingObjRemoveThenAdd
[       OK ] BufferOrchTest.BufferOrchTestReferencingObjRemoveThenAdd (45 ms)
[----------] 2 tests from BufferOrchTest (93 ms total)

[----------] 4 tests from CoppOrchTest
[ RUN      ] CoppOrchTest.TrapGroup_AddRemove
[       OK ] CoppOrchTest.TrapGroup_AddRemove (49 ms)
[ RUN      ] CoppOrchTest.TrapGroupWithPolicer_AddRemove
[       OK ] CoppOrchTest.TrapGroupWithPolicer_AddRemove (46 ms)
[ RUN      ] CoppOrchTest.Trap_AddRemove
[       OK ] CoppOrchTest.Trap_AddRemove (46 ms)
[ RUN      ] CoppOrchTest.TrapWithPolicer_AddRemove
[       OK ] CoppOrchTest.TrapWithPolicer_AddRemove (47 ms)
[----------] 4 tests from CoppOrchTest (188 ms total)

[----------] 4 tests from SaiSpy
[ RUN      ] SaiSpy.CURD
[       OK ] SaiSpy.CURD (0 ms)
[ RUN      ] SaiSpy.Same_Function_Signature_In_Same_API_Table
[       OK ] SaiSpy.Same_Function_Signature_In_Same_API_Table (0 ms)
[ RUN      ] SaiSpy.Same_Function_Signature_In_Different_API_Table
[       OK ] SaiSpy.Same_Function_Signature_In_Different_API_Table (0 ms)
[ RUN      ] SaiSpy.create_switch_and_acl_table
[       OK ] SaiSpy.create_switch_and_acl_table (0 ms)
[----------] 4 tests from SaiSpy (0 ms total)

[----------] 9 tests from ConsumerTest
[ RUN      ] ConsumerTest.ConsumerAddToSync_Set
[       OK ] ConsumerTest.ConsumerAddToSync_Set (0 ms)
[ RUN      ] ConsumerTest.ConsumerAddToSync_Del
[       OK ] ConsumerTest.ConsumerAddToSync_Del (0 ms)
[ RUN      ] ConsumerTest.ConsumerAddToSync_Set_Del
[       OK ] ConsumerTest.ConsumerAddToSync_Set_Del (0 ms)
[ RUN      ] ConsumerTest.ConsumerAddToSync_Del_Set
[       OK ] ConsumerTest.ConsumerAddToSync_Del_Set (65 ms)
[ RUN      ] ConsumerTest.ConsumerAddToSync_Set_Del_Set_Multi
[       OK ] ConsumerTest.ConsumerAddToSync_Set_Del_Set_Multi (100 ms)
[ RUN      ] ConsumerTest.ConsumerAddToSync_Set_Del_Set_Multi_In_Q
[       OK ] ConsumerTest.ConsumerAddToSync_Set_Del_Set_Multi_In_Q (2 ms)
[ RUN      ] ConsumerTest.ConsumerAddToSync_Del_Set_Setnew
[       OK ] ConsumerTest.ConsumerAddToSync_Del_Set_Setnew (0 ms)
[ RUN      ] ConsumerTest.ConsumerAddToSync_Del_Set_Setnew1
[       OK ] ConsumerTest.ConsumerAddToSync_Del_Set_Setnew1 (0 ms)
[ RUN      ] ConsumerTest.ConsumerAddToSync_Ind_Set_Del
[       OK ] ConsumerTest.ConsumerAddToSync_Ind_Set_Del (0 ms)
[----------] 9 tests from ConsumerTest (167 ms total)

[----------] 2 tests from BulkerTest
[ RUN      ] BulkerTest.BulkerAttrOrder
[       OK ] BulkerTest.BulkerAttrOrder (0 ms)
[ RUN      ] BulkerTest.BulkerPendindRemoval
[       OK ] BulkerTest.BulkerPendindRemoval (0 ms)
[----------] 2 tests from BulkerTest (0 ms total)

[----------] 1 test from SwssNetTest
[ RUN      ] SwssNetTest.CovertSAIPrefixToSONiCPrefix
[       OK ] SwssNetTest.CovertSAIPrefixToSONiCPrefix (0 ms)
[----------] 1 test from SwssNetTest (0 ms total)

[----------] Global test environment tear-down
[==========] 50 tests from 11 test suites ran. (1449 ms total)
[  PASSED  ] 50 tests.
```