### PR TITLE
[Counters] Improve performance by polling only configured ports buffer queue/pg counters

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -728,6 +728,7 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
     string grat_arp = "";
     string mpls = "";
     string ipv6_link_local_mode = "";
+    string loopback_action = "";
 
     for (auto idx : data)
     {
@@ -770,6 +771,10 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
         {
             vlanId = value;
         }
+        else if (field == "loopback_action")
+        {
+            loopback_action = value;
+        }
     }
 
     if (op == SET_COMMAND)
@@ -808,6 +813,13 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
             if (!nat_zone.empty())
             {
                 FieldValueTuple fvTuple("nat_zone", nat_zone);
+                data.push_back(fvTuple);
+            }
+
+            /* Set loopback action */
+            if (!loopback_action.empty())
+            {
+                FieldValueTuple fvTuple("loopback_action", loopback_action);
                 data.push_back(fvTuple);
             }
 

--- a/lib/asan.cpp
+++ b/lib/asan.cpp
@@ -4,6 +4,12 @@
 
 #include <logger.h>
 
+extern "C" {
+    const char* __lsan_default_suppressions() {
+        return "leak:__static_initialization_and_destruction_0\n";
+    }
+}
+
 static void swss_asan_sigterm_handler(int signo)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -153,7 +153,7 @@ static const acl_capabilities_t defaultAclActionsSupported =
     }
 };
 
-static acl_table_action_list_lookup_t defaultAclActionList = 
+static acl_table_action_list_lookup_t defaultAclActionList =
 {
     {
         // L3
@@ -326,7 +326,7 @@ static acl_table_action_list_lookup_t defaultAclActionList =
 // The match fields for certain ACL table type are not exactly the same between INGRESS and EGRESS.
 // For example, we can only match IN_PORT for PFCWD table type at INGRESS.
 // Hence we need to specify stage particular matching fields in stageMandatoryMatchFields
-static acl_table_match_field_lookup_t stageMandatoryMatchFields = 
+static acl_table_match_field_lookup_t stageMandatoryMatchFields =
 {
     {
         // TABLE_TYPE_PFCWD
@@ -2045,7 +2045,7 @@ bool AclTable::addMandatoryActions()
         // Add the default action list
         for (auto action : defaultAclActionList[type.getName()][stage])
         {
-            if (m_pAclOrch->isAclActionSupported(stage, acl_action))
+            if (m_pAclOrch->isAclActionSupported(stage, action))
             {
                 SWSS_LOG_INFO("Added default action for table type %s stage %s",
                                     type.getName().c_str(),

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1,5 +1,6 @@
 #include "tokenize.h"
 #include "bufferorch.h"
+#include "directory.h"
 #include "logger.h"
 #include "sai_serialize.h"
 #include "warm_restart.h"
@@ -16,6 +17,7 @@ extern sai_switch_api_t *sai_switch_api;
 extern sai_buffer_api_t *sai_buffer_api;
 
 extern PortsOrch *gPortsOrch;
+extern Directory<Orch*> gDirectory;
 extern sai_object_id_t gSwitchId;
 
 #define BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS  "60000"
@@ -812,6 +814,20 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                         return handle_status;
                     }
                 }
+                // create/remove a port queue counter for the queue buffer
+                else
+                {
+                    auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+                    auto queues = tokens[1];
+                    if (op == SET_COMMAND && flexCounterOrch->getQueueCountersState())
+                    {
+                        gPortsOrch->createPortBufferQueueCounters(port, queues);
+                    }
+                    else if (op == DEL_COMMAND && flexCounterOrch->getQueueCountersState())
+                    {
+                        gPortsOrch->removePortBufferQueueCounters(port, queues);
+                    }
+                }
             }
         }
     }
@@ -871,7 +887,7 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
     if (op == SET_COMMAND)
     {
         ref_resolve_status  resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name,
-                                             buffer_to_ref_table_map.at(buffer_profile_field_name), tuple, 
+                                             buffer_to_ref_table_map.at(buffer_profile_field_name), tuple,
                                              sai_buffer_profile, buffer_profile_name);
         if (ref_resolve_status::success != resolve_result)
         {
@@ -942,6 +958,20 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
                         if (handle_status != task_process_status::task_success)
                         {
                             return handle_status;
+                        }
+                    }
+                    // create or remove a port PG counter for the PG buffer
+                    else
+                    {
+                        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+                        auto pgs = tokens[1];
+                        if (op == SET_COMMAND && flexCounterOrch->getPgWatermarkCountersState())
+                        {
+                            gPortsOrch->createPortBufferPgCounters(port, pgs);
+                        }
+                        else if (op == DEL_COMMAND && flexCounterOrch->getPgWatermarkCountersState())
+                        {
+                            gPortsOrch->removePortBufferPgCounters(port, pgs);
                         }
                     }
                 }

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -37,14 +37,6 @@ public:
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
     const object_reference_map &getBufferPoolNameOidMap(void);
-    sai_object_id_t getZeroBufferPool(bool ingress)
-    {
-        return ingress ? m_ingressZeroBufferPool : m_egressZeroBufferPool;
-    }
-
-    void lockZeroBufferPool(bool ingress);
-    void unlockZeroBufferPool(bool ingress);
-    void setZeroBufferPool(bool direction, sai_object_id_t pool);
 
 private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(KeyOpFieldsValuesTuple &tuple);
@@ -80,10 +72,6 @@ private:
 
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
 
-    sai_object_id_t m_ingressZeroBufferPool;
-    sai_object_id_t m_egressZeroBufferPool;
-    int m_ingressZeroPoolRefCount;
-    int m_egressZeroPoolRefCount;
 };
 #endif /* SWSS_BUFFORCH_H */
 

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -123,7 +123,7 @@ private:
     bool storeFdbEntryState(const FdbUpdate& update);
     void notifyTunnelOrch(Port& port);
 
-    void clearFdbEntry(const MacAddress&, const sai_object_id_t&, const string&);
+    void clearFdbEntry(const FdbEntry&);
     void handleSyncdFlushNotif(const sai_object_id_t&, const sai_object_id_t&, const MacAddress& );
 };
 

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -10,6 +10,7 @@
 #include "debugcounterorch.h"
 #include "directory.h"
 #include "copporch.h"
+#include <swss/tokenize.h>
 #include "routeorch.h"
 #include "macsecorch.h"
 #include "flowcounterrouteorch.h"
@@ -62,6 +63,8 @@ unordered_map<string, string> flexCounterGroupMap =
 FlexCounterOrch::FlexCounterOrch(DBConnector *db, vector<string> &tableNames):
     Orch(db, tableNames),
     m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
+    m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME),
+    m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
     m_flexCounterDb(new DBConnector("FLEX_COUNTER_DB", 0)),
     m_flexCounterGroupTable(new ProducerTable(m_flexCounterDb.get(), FLEX_COUNTER_GROUP_TABLE)),
     m_gbflexCounterDb(new DBConnector("GB_FLEX_COUNTER_DB", 0)),
@@ -157,11 +160,13 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                         }
                         else if(key == QUEUE_KEY)
                         {
-                            gPortsOrch->generateQueueMap();
+                            gPortsOrch->generateQueueMap(getQueueConfigurations());
+                            m_queue_enabled = true;
                         }
                         else if(key == PG_WATERMARK_KEY)
                         {
-                            gPortsOrch->generatePriorityGroupMap();
+                            gPortsOrch->generatePriorityGroupMap(getPgConfigurations());
+                            m_pg_watermark_enabled = true;
                         }
                     }
                     if(gIntfsOrch && (key == RIF_KEY) && (value == "enable"))
@@ -245,6 +250,16 @@ bool FlexCounterOrch::getPortBufferDropCountersState() const
     return m_port_buffer_drop_counter_enabled;
 }
 
+bool FlexCounterOrch::getPgWatermarkCountersState() const
+{
+    return m_pg_watermark_enabled;
+}
+
+bool FlexCounterOrch::getQueueCountersState() const
+{
+    return m_queue_enabled;
+}
+
 bool FlexCounterOrch::bake()
 {
     /*
@@ -285,4 +300,166 @@ bool FlexCounterOrch::bake()
     }
     Consumer* consumer = dynamic_cast<Consumer *>(getExecutor(CFG_FLEX_COUNTER_TABLE_NAME));
     return consumer->addToSync(entries);
+}
+
+map<string, FlexCounterQueueStates> FlexCounterOrch::getQueueConfigurations()
+{
+    SWSS_LOG_ENTER();
+
+    map<string, FlexCounterQueueStates> queuesStateVector;
+    std::vector<std::string> portQueueKeys;
+    m_bufferQueueConfigTable.getKeys(portQueueKeys);
+
+    for (const auto& portQueueKey : portQueueKeys)
+    {
+        auto toks = tokenize(portQueueKey, '|');
+        if (toks.size() != 2)
+        {
+            SWSS_LOG_ERROR("Invalid BUFFER_QUEUE key: [%s]", portQueueKey.c_str());
+            continue;
+        }
+
+        auto configPortNames = tokenize(toks[0], ',');
+        auto configPortQueues = toks[1];
+        toks = tokenize(configPortQueues, '-');
+
+        for (const auto& configPortName : configPortNames)
+        {
+            uint32_t maxQueueNumber = gPortsOrch->getNumberOfPortSupportedQueueCounters(configPortName);
+            uint32_t maxQueueIndex = maxQueueNumber - 1;
+            uint32_t minQueueIndex = 0;
+
+            if (!queuesStateVector.count(configPortName))
+            {
+                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                queuesStateVector.insert(make_pair(configPortName, flexCounterQueueState));
+            }
+
+            try {
+                auto startIndex = to_uint<uint32_t>(toks[0], minQueueIndex, maxQueueIndex);
+                if (toks.size() > 1)
+                {
+                    auto endIndex = to_uint<uint32_t>(toks[1], minQueueIndex, maxQueueIndex);
+                    queuesStateVector.at(configPortName).enableQueueCounters(startIndex, endIndex);
+                }
+                else
+                {
+                    queuesStateVector.at(configPortName).enableQueueCounter(startIndex);
+                }
+            } catch (std::invalid_argument const& e) {
+                    SWSS_LOG_ERROR("Invalid queue index [%s] for port [%s]", configPortQueues.c_str(), configPortName.c_str());
+                    continue;
+            }
+        }
+    }
+
+    return queuesStateVector;
+}
+
+map<string, FlexCounterPgStates> FlexCounterOrch::getPgConfigurations()
+{
+    SWSS_LOG_ENTER();
+
+    map<string, FlexCounterPgStates> pgsStateVector;
+    std::vector<std::string> portPgKeys;
+    m_bufferPgConfigTable.getKeys(portPgKeys);
+
+    for (const auto& portPgKey : portPgKeys)
+    {
+        auto toks = tokenize(portPgKey, '|');
+        if (toks.size() != 2)
+        {
+            SWSS_LOG_ERROR("Invalid BUFFER_PG key: [%s]", portPgKey.c_str());
+            continue;
+        }
+
+        auto configPortNames = tokenize(toks[0], ',');
+        auto configPortPgs = toks[1];
+        toks = tokenize(configPortPgs, '-');
+
+        for (const auto& configPortName : configPortNames)
+        {
+            uint32_t maxPgNumber = gPortsOrch->getNumberOfPortSupportedPgCounters(configPortName);
+            uint32_t maxPgIndex = maxPgNumber - 1;
+            uint32_t minPgIndex = 0;
+
+            if (!pgsStateVector.count(configPortName))
+            {
+                FlexCounterPgStates flexCounterPgState(maxPgNumber);
+                pgsStateVector.insert(make_pair(configPortName, flexCounterPgState));
+            }
+
+            try {
+                auto startIndex = to_uint<uint32_t>(toks[0], minPgIndex, maxPgIndex);
+                if (toks.size() > 1)
+                {
+                    auto endIndex = to_uint<uint32_t>(toks[1], minPgIndex, maxPgIndex);
+                    pgsStateVector.at(configPortName).enablePgCounters(startIndex, endIndex);
+                }
+                else
+                {
+                    pgsStateVector.at(configPortName).enablePgCounter(startIndex);
+                }
+            } catch (std::invalid_argument const& e) {
+                    SWSS_LOG_ERROR("Invalid pg index [%s] for port [%s]", configPortPgs.c_str(), configPortName.c_str());
+                    continue;
+            }
+        }
+    }
+
+    return pgsStateVector;
+}
+
+FlexCounterQueueStates::FlexCounterQueueStates(uint32_t maxQueueNumber)
+{
+    SWSS_LOG_ENTER();
+    m_queueStates.resize(maxQueueNumber, false);
+}
+
+bool FlexCounterQueueStates::isQueueCounterEnabled(uint32_t index) const
+{
+    SWSS_LOG_ENTER();
+    return m_queueStates[index];
+}
+
+void FlexCounterQueueStates::enableQueueCounters(uint32_t startIndex, uint32_t endIndex)
+{
+    SWSS_LOG_ENTER();
+    for (uint32_t queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
+    {
+        enableQueueCounter(queueIndex);
+    }
+}
+
+void FlexCounterQueueStates::enableQueueCounter(uint32_t queueIndex)
+{
+    SWSS_LOG_ENTER();
+    m_queueStates[queueIndex] = true;
+}
+
+FlexCounterPgStates::FlexCounterPgStates(uint32_t maxPgNumber)
+{
+    SWSS_LOG_ENTER();
+    m_pgStates.resize(maxPgNumber, false);
+}
+
+bool FlexCounterPgStates::isPgCounterEnabled(uint32_t index) const
+{
+    SWSS_LOG_ENTER();
+    return m_pgStates[index];
+}
+
+void FlexCounterPgStates::enablePgCounters(uint32_t startIndex, uint32_t endIndex)
+{
+    SWSS_LOG_ENTER();
+    for (uint32_t pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
+    {
+        enablePgCounter(pgIndex);
+    }
+}
+
+void FlexCounterPgStates::enablePgCounter(uint32_t pgIndex)
+{
+    SWSS_LOG_ENTER();
+    m_pgStates[pgIndex] = true;
 }

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -10,6 +10,30 @@ extern "C" {
 #include "sai.h"
 }
 
+class FlexCounterQueueStates
+{
+public:
+    FlexCounterQueueStates(uint32_t maxQueueNumber);
+    bool isQueueCounterEnabled(uint32_t index) const;
+    void enableQueueCounters(uint32_t startIndex, uint32_t endIndex);
+    void enableQueueCounter(uint32_t queueIndex);
+
+private:
+    std::vector<bool> m_queueStates{};
+};
+
+class FlexCounterPgStates
+{
+public:
+    FlexCounterPgStates(uint32_t maxPgNumber);
+    bool isPgCounterEnabled(uint32_t index) const;
+    void enablePgCounters(uint32_t startIndex, uint32_t endIndex);
+    void enablePgCounter(uint32_t pgIndex);
+
+private:
+    std::vector<bool> m_pgStates{};
+};
+
 class FlexCounterOrch: public Orch
 {
 public:
@@ -18,6 +42,10 @@ public:
     virtual ~FlexCounterOrch(void);
     bool getPortCountersState() const;
     bool getPortBufferDropCountersState() const;
+    bool getPgWatermarkCountersState() const;
+    bool getQueueCountersState() const;
+    map<string, FlexCounterQueueStates> getQueueConfigurations();
+    map<string, FlexCounterPgStates> getPgConfigurations();
     bool getHostIfTrapCounterState() const {return m_hostif_trap_counter_enabled;}
     bool getRouteFlowCountersState() const {return m_route_flow_counter_enabled;}
     bool bake() override;
@@ -29,9 +57,13 @@ private:
     shared_ptr<ProducerTable> m_gbflexCounterGroupTable = nullptr;
     bool m_port_counter_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
+    bool m_pg_watermark_enabled = false;
+    bool m_queue_enabled = false;
     bool m_hostif_trap_counter_enabled = false;
     bool m_route_flow_counter_enabled = false;
     Table m_flexCounterConfigTable;
+    Table m_bufferQueueConfigTable;
+    Table m_bufferPgConfigTable;
 };
 
 #endif

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -54,7 +54,9 @@ public:
     void addRifToFlexCounter(const string&, const string&, const string&);
     void removeRifFromFlexCounter(const string&, const string&);
 
-    bool setIntf(const string& alias, sai_object_id_t vrf_id = gVirtualRouterId, const IpPrefix *ip_prefix = nullptr, const bool adminUp = true, const uint32_t mtu = 0);
+    bool setIntfLoopbackAction(const Port &port, string actionStr);
+    bool getSaiLoopbackAction(const string &actionStr, sai_packet_action_t &action);
+    bool setIntf(const string& alias, sai_object_id_t vrf_id = gVirtualRouterId, const IpPrefix *ip_prefix = nullptr, const bool adminUp = true, const uint32_t mtu = 0, string loopbackAction = "");
     bool removeIntf(const string& alias, sai_object_id_t vrf_id = gVirtualRouterId, const IpPrefix *ip_prefix = nullptr);
 
     void addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
@@ -95,7 +97,7 @@ private:
     std::string getRifRateInitTableKey(std::string s);
     void cleanUpRifFromCounterDb(const string &id, const string &name);
 
-    bool addRouterIntfs(sai_object_id_t vrf_id, Port &port);
+    bool addRouterIntfs(sai_object_id_t vrf_id, Port &port, string loopbackAction);
     bool removeRouterIntfs(Port &port);
 
     void addDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix);

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -2340,10 +2340,6 @@ void MACsecOrch::installCounter(
     sai_object_id_t obj_id,
     const std::vector<std::string> &stats)
 {
-    FieldValueTuple tuple(obj_name, sai_serialize_object_id(obj_id));
-    vector<FieldValueTuple> fields;
-    fields.push_back(tuple);
-
     std::unordered_set<std::string> counter_stats;
     for (const auto &stat : stats)
     {
@@ -2353,12 +2349,11 @@ void MACsecOrch::installCounter(
     {
         case CounterType::MACSEC_SA_ATTR:
             MACsecSaAttrStatManager(ctx).setCounterIdList(obj_id, counter_type, counter_stats);
-            MACsecCountersMap(ctx).set("", fields);
             break;
 
         case CounterType::MACSEC_SA:
             MACsecSaStatManager(ctx).setCounterIdList(obj_id, counter_type, counter_stats);
-            MACsecCountersMap(ctx).set("", fields);
+            MACsecCountersMap(ctx).hset("", obj_name, sai_serialize_object_id(obj_id));
             break;
 
         case CounterType::MACSEC_FLOW:
@@ -2383,19 +2378,11 @@ void MACsecOrch::uninstallCounter(
     {
         case CounterType::MACSEC_SA_ATTR:
             MACsecSaAttrStatManager(ctx).clearCounterIdList(obj_id);
-            m_counter_db.hdel(COUNTERS_MACSEC_NAME_MAP, obj_name);
             break;
 
         case CounterType::MACSEC_SA:
             MACsecSaStatManager(ctx).clearCounterIdList(obj_id);
-            if (direction == SAI_MACSEC_DIRECTION_EGRESS)
-            {
-                m_counter_db.hdel(COUNTERS_MACSEC_SA_TX_NAME_MAP, obj_name);
-            }
-            else
-            {
-                m_counter_db.hdel(COUNTERS_MACSEC_SA_RX_NAME_MAP, obj_name);
-            }
+            MACsecCountersMap(ctx).hdel("", obj_name);
             break;
 
         case CounterType::MACSEC_FLOW:

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -3,7 +3,6 @@
 #include "logger.h"
 #include "sai_serialize.h"
 #include "portsorch.h"
-#include "bufferorch.h"
 #include <vector>
 #include <inttypes.h>
 
@@ -27,7 +26,6 @@
 extern sai_object_id_t gSwitchId;
 extern PortsOrch *gPortsOrch;
 extern AclOrch * gAclOrch;
-extern BufferOrch *gBufferOrch;
 extern sai_port_api_t *sai_port_api;
 extern sai_queue_api_t *sai_queue_api;
 extern sai_buffer_api_t *sai_buffer_api;
@@ -567,7 +565,7 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
         return;
     }
 
-    setPriorityGroupAndQueueLockFlag(portInstance, true);
+    setQueueLockFlag(portInstance, true);
 
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
@@ -583,7 +581,7 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
     sai_object_id_t oldQueueProfileId = attr.value.oid;
 
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
-    attr.value.oid = ZeroBufferProfile::getZeroBufferProfile(false);
+    attr.value.oid = ZeroBufferProfile::getZeroBufferProfile();
 
     // Set our zero buffer profile
     status = sai_queue_api->set_queue_attribute(queue, &attr);
@@ -595,35 +593,6 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
 
     // Save original buffer profile
     m_originalQueueBufferProfile = oldQueueProfileId;
-
-    // Get PG
-    sai_object_id_t pg = portInstance.m_priority_group_ids[static_cast <size_t> (queueId)];
-
-    attr.id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
-
-    // Get PG's buffer profile
-    status = sai_buffer_api->get_ingress_priority_group_attribute(pg, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to get buffer profile ID on PG 0x%" PRIx64 ": %d", pg, status);
-        return;
-    }
-
-    // Set zero profile to PG
-    sai_object_id_t oldPgProfileId = attr.value.oid;
-
-    attr.id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
-    attr.value.oid = ZeroBufferProfile::getZeroBufferProfile(true);
-
-    status = sai_buffer_api->set_ingress_priority_group_attribute(pg, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to set buffer profile ID on pg 0x%" PRIx64 ": %d", pg, status);
-        return;
-    }
-
-    // Save original buffer profile
-    m_originalPgBufferProfile = oldPgProfileId;
 }
 
 PfcWdZeroBufferHandler::~PfcWdZeroBufferHandler(void)
@@ -649,41 +618,12 @@ PfcWdZeroBufferHandler::~PfcWdZeroBufferHandler(void)
         return;
     }
 
-    auto idx = size_t(getQueueId());
-    sai_object_id_t pg = portInstance.m_priority_group_ids[idx];
-    sai_object_id_t pending_profile_id = portInstance.m_priority_group_pending_profile[idx];
-
-    attr.id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
-
-    if (pending_profile_id != SAI_NULL_OBJECT_ID)
-    {
-        attr.value.oid = pending_profile_id;
-        SWSS_LOG_NOTICE("Priority group %zd on port %s has been restored to pending profile 0x%" PRIx64,
-                        idx, portInstance.m_alias.c_str(), pending_profile_id);
-        portInstance.m_priority_group_pending_profile[idx] = SAI_NULL_OBJECT_ID;
-    }
-    else
-    {
-        attr.value.oid = m_originalPgBufferProfile;
-        SWSS_LOG_NOTICE("Priority group %zd on port %s has been restored to original profile 0x%" PRIx64,
-                        idx, portInstance.m_alias.c_str(), m_originalPgBufferProfile);
-    }
-
-    // Set our zero buffer profile
-    status = sai_buffer_api->set_ingress_priority_group_attribute(pg, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to set buffer profile ID on queue 0x%" PRIx64 ": %d", getQueue(), status);
-        return;
-    }
-
-    setPriorityGroupAndQueueLockFlag(portInstance, false);
+    setQueueLockFlag(portInstance, false);
 }
 
-void PfcWdZeroBufferHandler::setPriorityGroupAndQueueLockFlag(Port& port, bool isLocked) const
+void PfcWdZeroBufferHandler::setQueueLockFlag(Port& port, bool isLocked) const
 {
-    // set lock bits on PG and queue
-    port.m_priority_group_lock[static_cast<size_t>(getQueueId())] = isLocked;
+    // set lock bits on queue
     for (size_t i = 0; i < port.m_queue_ids.size(); ++i)
     {
         if (port.m_queue_ids[i] == getQueue())
@@ -703,9 +643,8 @@ PfcWdZeroBufferHandler::ZeroBufferProfile::~ZeroBufferProfile(void)
 {
     SWSS_LOG_ENTER();
 
-    // Destroy ingress and egress profiles and pools
-    destroyZeroBufferProfile(true);
-    destroyZeroBufferProfile(false);
+    // Destroy egress profiles and pools
+    destroyZeroBufferProfile();
 }
 
 PfcWdZeroBufferHandler::ZeroBufferProfile &PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance(void)
@@ -717,38 +656,19 @@ PfcWdZeroBufferHandler::ZeroBufferProfile &PfcWdZeroBufferHandler::ZeroBufferPro
     return instance;
 }
 
-sai_object_id_t& PfcWdZeroBufferHandler::ZeroBufferProfile::getPool(bool ingress)
-{
-    // If there is a cached zero buffer pool, just use it
-    // else fetch zero buffer pool from buffer orch
-    // If there is one, use it and increase the reference number.
-    // otherwise, just return NULL OID
-    // PfcWdZeroBufferHandler will create it later and notify buffer orch later
-    auto &poolId = ingress ? m_zeroIngressBufferPool : m_zeroEgressBufferPool;
-    if (poolId == SAI_NULL_OBJECT_ID)
-    {
-        poolId = gBufferOrch->getZeroBufferPool(ingress);
-        if (poolId != SAI_NULL_OBJECT_ID)
-        {
-            gBufferOrch->lockZeroBufferPool(ingress);
-        }
-    }
-    return poolId;
-}
-
-sai_object_id_t PfcWdZeroBufferHandler::ZeroBufferProfile::getZeroBufferProfile(bool ingress)
+sai_object_id_t PfcWdZeroBufferHandler::ZeroBufferProfile::getZeroBufferProfile()
 {
     SWSS_LOG_ENTER();
 
-    if (getInstance().getProfile(ingress) == SAI_NULL_OBJECT_ID)
+    if (getInstance().getProfile() == SAI_NULL_OBJECT_ID)
     {
-        getInstance().createZeroBufferProfile(ingress);
+        getInstance().createZeroBufferProfile();
     }
 
-    return getInstance().getProfile(ingress);
+    return getInstance().getProfile();
 }
 
-void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ingress)
+void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile()
 {
     SWSS_LOG_ENTER();
 
@@ -756,60 +676,51 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ing
     vector<sai_attribute_t> attribs;
     sai_status_t status;
 
-    auto &poolId = getPool(ingress);
+    // Create zero pool
+    attr.id = SAI_BUFFER_POOL_ATTR_SIZE;
+    attr.value.u64 = 0;
+    attribs.push_back(attr);
 
-    if (SAI_NULL_OBJECT_ID == poolId)
+    attr.id = SAI_BUFFER_POOL_ATTR_TYPE;
+    attr.value.u32 = SAI_BUFFER_POOL_TYPE_EGRESS;
+    attribs.push_back(attr);
+
+    attr.id = SAI_BUFFER_POOL_ATTR_THRESHOLD_MODE;
+    attr.value.u32 = SAI_BUFFER_POOL_THRESHOLD_MODE_DYNAMIC;
+    attribs.push_back(attr);
+
+    status = sai_buffer_api->create_buffer_pool(
+        &getPool(),
+        gSwitchId,
+        static_cast<uint32_t>(attribs.size()),
+        attribs.data());
+    if (status != SAI_STATUS_SUCCESS)
     {
-        // Create zero pool
-        attr.id = SAI_BUFFER_POOL_ATTR_SIZE;
-        attr.value.u64 = 0;
-        attribs.push_back(attr);
-
-        attr.id = SAI_BUFFER_POOL_ATTR_TYPE;
-        attr.value.u32 = ingress ? SAI_BUFFER_POOL_TYPE_INGRESS : SAI_BUFFER_POOL_TYPE_EGRESS;
-        attribs.push_back(attr);
-
-        attr.id = SAI_BUFFER_POOL_ATTR_THRESHOLD_MODE;
-        attr.value.u32 = SAI_BUFFER_POOL_THRESHOLD_MODE_STATIC;
-        attribs.push_back(attr);
-
-        status = sai_buffer_api->create_buffer_pool(
-            &poolId,
-            gSwitchId,
-            static_cast<uint32_t>(attribs.size()),
-            attribs.data());
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to create dynamic zero buffer pool for PFC WD: %d", status);
-            return;
-        }
-
-        // Pass the ownership to BufferOrch
-        gBufferOrch->setZeroBufferPool(ingress, poolId);
-        gBufferOrch->lockZeroBufferPool(ingress);
+        SWSS_LOG_ERROR("Failed to create dynamic zero buffer pool for PFC WD: %d", status);
+        return;
     }
 
     // Create zero profile
     attribs.clear();
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_POOL_ID;
-    attr.value.oid = getPool(ingress);
+    attr.value.oid = getPool();
     attribs.push_back(attr);
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE;
-    attr.value.u32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_STATIC;
+    attr.value.u32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_DYNAMIC;
     attribs.push_back(attr);
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE;
     attr.value.u64 = 0;
     attribs.push_back(attr);
 
-    attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_STATIC_TH;
-    attr.value.s8 = 0;
+    attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH;
+    attr.value.s8 = -8;
     attribs.push_back(attr);
 
     status = sai_buffer_api->create_buffer_profile(
-            &getProfile(ingress),
+            &getProfile(),
             gSwitchId,
             static_cast<uint32_t>(attribs.size()),
             attribs.data());
@@ -820,23 +731,20 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ing
     }
 }
 
-void PfcWdZeroBufferHandler::ZeroBufferProfile::destroyZeroBufferProfile(bool ingress)
+void PfcWdZeroBufferHandler::ZeroBufferProfile::destroyZeroBufferProfile()
 {
     SWSS_LOG_ENTER();
 
-    if (getProfile(ingress) != SAI_NULL_OBJECT_ID)
+    sai_status_t status = sai_buffer_api->remove_buffer_profile(getProfile());
+    if (status != SAI_STATUS_SUCCESS)
     {
-        sai_status_t status = sai_buffer_api->remove_buffer_profile(getProfile(ingress));
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to remove static zero buffer profile for PFC WD: %d", status);
-            return;
-        }
+        SWSS_LOG_ERROR("Failed to remove static zero buffer profile for PFC WD: %d", status);
+        return;
     }
 
-    auto &pool = ingress ? m_zeroIngressBufferPool : m_zeroEgressBufferPool;
-    if (pool != SAI_NULL_OBJECT_ID)
+    status = sai_buffer_api->remove_buffer_pool(getPool());
+    if (status != SAI_STATUS_SUCCESS)
     {
-        gBufferOrch->unlockZeroBufferPool(ingress);
+        SWSS_LOG_ERROR("Failed to remove static zero buffer pool for PFC WD: %d", status);
     }
 }

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -125,39 +125,39 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
 
     private:
         /*
-         * Sets lock bits on port's priority group and queue
-         * to protect them from being changed by other Orch's
-         */
-        void setPriorityGroupAndQueueLockFlag(Port& port, bool isLocked) const;
+         * Sets lock bits on port's queue
+         * to protect it from being changed by other Orch's
+        */
+        void setQueueLockFlag(Port& port, bool isLocked) const;
 
         // Singletone class for keeping shared data - zero buffer profiles
         class ZeroBufferProfile
         {
             public:
                 ~ZeroBufferProfile(void);
-                static sai_object_id_t getZeroBufferProfile(bool ingress);
+                static sai_object_id_t getZeroBufferProfile();
 
             private:
                 ZeroBufferProfile(void);
                 static ZeroBufferProfile &getInstance(void);
-                void createZeroBufferProfile(bool ingress);
-                void destroyZeroBufferProfile(bool ingress);
+                void createZeroBufferProfile();
+                void destroyZeroBufferProfile();
 
-                sai_object_id_t& getProfile(bool ingress)
+                sai_object_id_t& getProfile()
                 {
-                    return ingress ? m_zeroIngressBufferProfile : m_zeroEgressBufferProfile;
+                    return m_zeroEgressBufferProfile;
                 }
 
-                sai_object_id_t& getPool(bool ingress);
+                sai_object_id_t& getPool()
+                {
+                    return m_zeroEgressBufferPool;
+                }
 
-                sai_object_id_t m_zeroIngressBufferPool = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferPool = SAI_NULL_OBJECT_ID;
-                sai_object_id_t m_zeroIngressBufferProfile = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferProfile = SAI_NULL_OBJECT_ID;
         };
 
         sai_object_id_t m_originalQueueBufferProfile = SAI_NULL_OBJECT_ID;
-        sai_object_id_t m_originalPgBufferProfile = SAI_NULL_OBJECT_ID;
 };
 
 // PFC queue that implements drop action by draining queue via SAI

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -153,15 +153,13 @@ public:
     bool      m_mpls = false;
 
     /*
-     * Following two bit vectors are used to lock
-     * the PG/queue from being changed in BufferOrch.
+     * Following bit vector is used to lock
+     * the queue from being changed in BufferOrch.
      * The use case scenario is when PfcWdZeroBufferHandler
-     * sets zero buffer profile it should protect PG/queue
+     * sets zero buffer profile it should protect queue
      * from being overwritten in BufferOrch.
      */
     std::vector<bool> m_queue_lock;
-    std::vector<bool> m_priority_group_lock;
-    std::vector<sai_object_id_t> m_priority_group_pending_profile;
 
     std::unordered_set<sai_object_id_t> m_ingress_acl_tables_uset;
     std::unordered_set<sai_object_id_t> m_egress_acl_tables_uset;

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -151,7 +151,6 @@ public:
     sai_port_interface_type_t m_interface_type;
     std::vector<uint32_t> m_adv_interface_types;
     bool      m_mpls = false;
-
     /*
      * Following bit vector is used to lock
      * the queue from being changed in BufferOrch.

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4162,8 +4162,6 @@ void PortsOrch::initializePriorityGroups(Port &port)
     SWSS_LOG_INFO("Get %d priority groups for port %s", attr.value.u32, port.m_alias.c_str());
 
     port.m_priority_group_ids.resize(attr.value.u32);
-    port.m_priority_group_lock.resize(attr.value.u32);
-    port.m_priority_group_pending_profile.resize(attr.value.u32);
 
     if (attr.value.u32 == 0)
     {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2461,18 +2461,6 @@ bool PortsOrch::initPort(const string &alias, const string &role, const int inde
                     port_buffer_drop_stat_manager.setCounterIdList(p.m_port_id, CounterType::PORT, port_buffer_drop_stats);
                 }
 
-                /* when a port is added and priority group map counter is enabled --> we need to add pg counter for it */
-                if (m_isPriorityGroupMapGenerated)
-                {
-                    generatePriorityGroupMapPerPort(p);
-                }
-
-                /* when a port is added and queue map counter is enabled --> we need to add queue map counter for it */
-                if (m_isQueueMapGenerated)
-                {
-                    generateQueueMapPerPort(p);
-                }
-
                 PortUpdate update = { p, true };
                 notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
 
@@ -2523,18 +2511,6 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     if (flex_counters_orch->getPortBufferDropCountersState())
     {
         port_buffer_drop_stat_manager.clearCounterIdList(p.m_port_id);
-    }
-
-    /* remove pg port counters */
-    if (m_isPriorityGroupMapGenerated)
-    {
-        removePriorityGroupMapPerPort(p);
-    }
-
-    /* remove queue port counters */
-    if (m_isQueueMapGenerated)
-    {
-        removeQueueMapPerPort(p);
     }
 
     /* remove port name map from counter table */
@@ -5489,7 +5465,7 @@ bool PortsOrch::removeTunnel(Port tunnel)
     return true;
 }
 
-void PortsOrch::generateQueueMap()
+void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector)
 {
     if (m_isQueueMapGenerated)
     {
@@ -5500,52 +5476,20 @@ void PortsOrch::generateQueueMap()
     {
         if (it.second.m_type == Port::PHY)
         {
-            generateQueueMapPerPort(it.second);
+            if (!queuesStateVector.count(it.second.m_alias))
+            {
+                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
+                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
+            }
+            generateQueueMapPerPort(it.second, queuesStateVector.at(it.second.m_alias));
         }
     }
 
     m_isQueueMapGenerated = true;
 }
 
-void PortsOrch::removeQueueMapPerPort(const Port& port)
-{
-    /* Remove the Queue map in the Counter DB */
-
-    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << queueIndex;
-        std::unordered_set<string> counter_stats;
-
-        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
-
-        m_queueTable->hdel("",name.str());
-        m_queuePortTable->hdel("",id);
-
-        string queueType;
-        uint8_t queueRealIndex = 0;
-        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
-        {
-            m_queueTypeTable->hdel("",id);
-            m_queueIndexTable->hdel("",id);
-        }
-
-        for (const auto& it: queue_stat_ids)
-        {
-            counter_stats.emplace(sai_serialize_queue_stat(it));
-        }
-        queue_stat_manager.clearCounterIdList(port.m_queue_ids[queueIndex]);
-
-        /* remove watermark queue counters */
-        string key = getQueueWatermarkFlexCounterTableKey(id);
-
-        m_flexCounterTable->del(key);
-    }
-
-    CounterCheckOrch::getInstance().removePort(port);
-}
-
-void PortsOrch::generateQueueMapPerPort(const Port& port)
+void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState)
 {
     /* Create the Queue map in the Counter DB */
     /* Add stat counters to flex_counter */
@@ -5561,16 +5505,20 @@ void PortsOrch::generateQueueMapPerPort(const Port& port)
 
         const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
 
-        queueVector.emplace_back(name.str(), id);
-        queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
-
         string queueType;
         uint8_t queueRealIndex = 0;
         if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
         {
+            if (!queuesState.isQueueCounterEnabled(queueRealIndex))
+            {
+                continue;
+            }
             queueTypeVector.emplace_back(id, queueType);
             queueIndexVector.emplace_back(id, to_string(queueRealIndex));
         }
+
+        queueVector.emplace_back(name.str(), id);
+        queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
 
         // Install a flex counter for this queue to track stats
         std::unordered_set<string> counter_stats;
@@ -5605,7 +5553,112 @@ void PortsOrch::generateQueueMapPerPort(const Port& port)
     CounterCheckOrch::getInstance().addPort(port);
 }
 
-void PortsOrch::generatePriorityGroupMap()
+void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
+{
+    SWSS_LOG_ENTER();
+
+    /* Create the Queue map in the Counter DB */
+    /* Add stat counters to flex_counter */
+    vector<FieldValueTuple> queueVector;
+    vector<FieldValueTuple> queuePortVector;
+    vector<FieldValueTuple> queueIndexVector;
+    vector<FieldValueTuple> queueTypeVector;
+
+    auto toks = tokenize(queues, '-');
+    auto startIndex = to_uint<uint32_t>(toks[0]);
+    auto endIndex = startIndex;
+    if (toks.size() > 1)
+    {
+        endIndex = to_uint<uint32_t>(toks[1]);
+    }
+
+    for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
+    {
+        std::ostringstream name;
+        name << port.m_alias << ":" << queueIndex;
+
+        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
+
+        string queueType;
+        uint8_t queueRealIndex = 0;
+        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
+        {
+            queueTypeVector.emplace_back(id, queueType);
+            queueIndexVector.emplace_back(id, to_string(queueRealIndex));
+        }
+
+        queueVector.emplace_back(name.str(), id);
+        queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
+
+        // Install a flex counter for this queue to track stats
+        std::unordered_set<string> counter_stats;
+        for (const auto& it: queue_stat_ids)
+        {
+            counter_stats.emplace(sai_serialize_queue_stat(it));
+        }
+        queue_stat_manager.setCounterIdList(port.m_queue_ids[queueIndex], CounterType::QUEUE, counter_stats);
+
+        /* add watermark queue counters */
+        string key = getQueueWatermarkFlexCounterTableKey(id);
+
+        string delimiter("");
+        std::ostringstream counters_stream;
+        for (const auto& it: queueWatermarkStatIds)
+        {
+            counters_stream << delimiter << sai_serialize_queue_stat(it);
+            delimiter = comma;
+        }
+
+        vector<FieldValueTuple> fieldValues;
+        fieldValues.emplace_back(QUEUE_COUNTER_ID_LIST, counters_stream.str());
+
+        m_flexCounterTable->set(key, fieldValues);
+    }
+
+    m_queueTable->set("", queueVector);
+    m_queuePortTable->set("", queuePortVector);
+    m_queueIndexTable->set("", queueIndexVector);
+    m_queueTypeTable->set("", queueTypeVector);
+
+    CounterCheckOrch::getInstance().addPort(port);
+}
+
+void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
+{
+    SWSS_LOG_ENTER();
+
+    /* Remove the Queues maps in the Counter DB */
+    /* Remove stat counters from flex_counter DB */
+    auto toks = tokenize(queues, '-');
+    auto startIndex = to_uint<uint32_t>(toks[0]);
+    auto endIndex = startIndex;
+    if (toks.size() > 1)
+    {
+        endIndex = to_uint<uint32_t>(toks[1]);
+    }
+
+    for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
+    {
+        std::ostringstream name;
+        name << port.m_alias << ":" << queueIndex;
+        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
+
+        /* Remove watermark queue counters */
+        string key = getQueueWatermarkFlexCounterTableKey(id);
+        m_flexCounterTable->del(key);
+
+        // Remove the flex counter for this queue
+        queue_stat_manager.clearCounterIdList(port.m_queue_ids[queueIndex]);
+
+        // Remove the queue counter from counters DB maps
+        m_queueTable->hdel("", name.str());
+        m_queuePortTable->hdel("", id);
+        m_queueIndexTable->hdel("", id);
+        m_queueTypeTable->hdel("", id);
+    }
+}
+
+void PortsOrch::generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsStateVector)
 {
     if (m_isPriorityGroupMapGenerated)
     {
@@ -5616,40 +5669,20 @@ void PortsOrch::generatePriorityGroupMap()
     {
         if (it.second.m_type == Port::PHY)
         {
-            generatePriorityGroupMapPerPort(it.second);
+            if (!pgsStateVector.count(it.second.m_alias))
+            {
+                auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
+                FlexCounterPgStates flexCounterPgState(maxPgNumber);
+                pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
+            }
+            generatePriorityGroupMapPerPort(it.second, pgsStateVector.at(it.second.m_alias));
         }
     }
 
     m_isPriorityGroupMapGenerated = true;
 }
 
-void PortsOrch::removePriorityGroupMapPerPort(const Port& port)
-{
-    /* Remove the PG map in the Counter DB */
-
-    for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << pgIndex;
-
-        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
-        string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
-
-        m_pgTable->hdel("",name.str());
-        m_pgPortTable->hdel("",id);
-        m_pgIndexTable->hdel("",id);
-
-        m_flexCounterTable->del(key);
-
-        key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
-        /* remove dropped packets counters to flex_counter */
-        m_flexCounterTable->del(key);
-    }
-
-    CounterCheckOrch::getInstance().removePort(port);
-}
-
-void PortsOrch::generatePriorityGroupMapPerPort(const Port& port)
+void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState)
 {
     /* Create the PG map in the Counter DB */
     /* Add stat counters to flex_counter */
@@ -5658,6 +5691,78 @@ void PortsOrch::generatePriorityGroupMapPerPort(const Port& port)
     vector<FieldValueTuple> pgIndexVector;
 
     for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
+    {
+        if (!pgsState.isPgCounterEnabled(static_cast<uint32_t>(pgIndex)))
+        {
+            continue;
+        }
+        std::ostringstream name;
+        name << port.m_alias << ":" << pgIndex;
+
+        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
+
+        pgVector.emplace_back(name.str(), id);
+        pgPortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
+        pgIndexVector.emplace_back(id, to_string(pgIndex));
+
+        string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
+
+        std::string delimiter = "";
+        std::ostringstream counters_stream;
+        /* Add watermark counters to flex_counter */
+        for (const auto& it: ingressPriorityGroupWatermarkStatIds)
+        {
+            counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
+            delimiter = comma;
+        }
+
+        vector<FieldValueTuple> fieldValues;
+        fieldValues.emplace_back(PG_COUNTER_ID_LIST, counters_stream.str());
+        m_flexCounterTable->set(key, fieldValues);
+
+        delimiter = "";
+        std::ostringstream ingress_pg_drop_packets_counters_stream;
+        key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
+        /* Add dropped packets counters to flex_counter */
+        for (const auto& it: ingressPriorityGroupDropStatIds)
+        {
+            ingress_pg_drop_packets_counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
+            if (delimiter.empty())
+            {
+                delimiter = comma;
+            }
+        }
+        fieldValues.clear();
+        fieldValues.emplace_back(PG_COUNTER_ID_LIST, ingress_pg_drop_packets_counters_stream.str());
+        m_flexCounterTable->set(key, fieldValues);
+    }
+
+    m_pgTable->set("", pgVector);
+    m_pgPortTable->set("", pgPortVector);
+    m_pgIndexTable->set("", pgIndexVector);
+
+    CounterCheckOrch::getInstance().addPort(port);
+}
+
+void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
+{
+    SWSS_LOG_ENTER();
+
+    /* Create the PG map in the Counter DB */
+    /* Add stat counters to flex_counter */
+    vector<FieldValueTuple> pgVector;
+    vector<FieldValueTuple> pgPortVector;
+    vector<FieldValueTuple> pgIndexVector;
+
+    auto toks = tokenize(pgs, '-');
+    auto startIndex = to_uint<uint32_t>(toks[0]);
+    auto endIndex = startIndex;
+    if (toks.size() > 1)
+    {
+        endIndex = to_uint<uint32_t>(toks[1]);
+    }
+
+    for (auto pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
     {
         std::ostringstream name;
         name << port.m_alias << ":" << pgIndex;
@@ -5705,6 +5810,41 @@ void PortsOrch::generatePriorityGroupMapPerPort(const Port& port)
     m_pgIndexTable->set("", pgIndexVector);
 
     CounterCheckOrch::getInstance().addPort(port);
+}
+
+void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
+{
+    SWSS_LOG_ENTER();
+
+    /* Remove the Pgs maps in the Counter DB */
+    /* Remove stat counters from flex_counter DB */
+    auto toks = tokenize(pgs, '-');
+    auto startIndex = to_uint<uint32_t>(toks[0]);
+    auto endIndex = startIndex;
+    if (toks.size() > 1)
+    {
+        endIndex = to_uint<uint32_t>(toks[1]);
+    }
+
+    for (auto pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
+    {
+        std::ostringstream name;
+        name << port.m_alias << ":" << pgIndex;
+        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
+
+        /* Remove dropped packets counters from flex_counter */
+        string key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
+        m_flexCounterTable->del(key);
+
+        /* Remove watermark counters from flex_counter */
+        key = getPriorityGroupWatermarkFlexCounterTableKey(id);
+        m_flexCounterTable->del(key);
+
+        // Remove the pg counter from counters DB maps
+        m_pgTable->hdel("", name.str());
+        m_pgPortTable->hdel("", id);
+        m_pgIndexTable->hdel("", id);
+    }
 }
 
 void PortsOrch::generatePortCounterMap()
@@ -5755,6 +5895,16 @@ void PortsOrch::generatePortBufferDropCounterMap()
     }
 
     m_isPortBufferDropCounterMapGenerated = true;
+}
+
+uint32_t PortsOrch::getNumberOfPortSupportedPgCounters(string port)
+{
+    return static_cast<uint32_t>(m_portList[port].m_priority_group_ids.size());
+}
+
+uint32_t PortsOrch::getNumberOfPortSupportedQueueCounters(string port)
+{
+    return static_cast<uint32_t>(m_portList[port].m_queue_ids.size());
 }
 
 void PortsOrch::doTask(NotificationConsumer &consumer)

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -127,9 +127,17 @@ public:
 
     bool setPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t pfc_bitmask);
     bool getPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t *pfc_bitmask);
+    
+    void generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector);
+    uint32_t getNumberOfPortSupportedQueueCounters(string port);
+    void createPortBufferQueueCounters(const Port &port, string queues);
+    void removePortBufferQueueCounters(const Port &port, string queues);
 
-    void generateQueueMap();
-    void generatePriorityGroupMap();
+    void generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsStateVector);
+    uint32_t getNumberOfPortSupportedPgCounters(string port);
+    void createPortBufferPgCounters(const Port &port, string pgs);
+    void removePortBufferPgCounters(const Port& port, string pgs);
+
     void generatePortCounterMap();
     void generatePortBufferDropCounterMap();
 
@@ -323,13 +331,9 @@ private:
     bool getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index);
 
     bool m_isQueueMapGenerated = false;
-    void generateQueueMapPerPort(const Port& port);
-    void removeQueueMapPerPort(const Port& port);
-
+    void generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState);
     bool m_isPriorityGroupMapGenerated = false;
-    void generatePriorityGroupMapPerPort(const Port& port);
-    void removePriorityGroupMapPerPort(const Port& port);
-
+    void generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState);
     bool m_isPortCounterMapGenerated = false;
     bool m_isPortBufferDropCounterMapGenerated = false;
 

--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -20,6 +20,38 @@ extern sai_next_hop_api_t* sai_next_hop_api;
 extern RouteOrch *gRouteOrch;
 extern CrmOrch *gCrmOrch;
 
+const map<string, sai_my_sid_entry_endpoint_behavior_t> end_behavior_map =
+{
+    {"end",                SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_E},
+    {"end.x",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_X},
+    {"end.t",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_T},
+    {"end.dx6",            SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6},
+    {"end.dx4",            SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4},
+    {"end.dt4",            SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4},
+    {"end.dt6",            SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6},
+    {"end.dt46",           SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46},
+    {"end.b6.encaps",      SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS},
+    {"end.b6.encaps.red",  SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS_RED},
+    {"end.b6.insert",      SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT},
+    {"end.b6.insert.red",  SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT_RED},
+    {"udx6",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6},
+    {"udx4",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4},
+    {"udt6",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6},
+    {"udt4",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4},
+    {"udt46",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46},
+    {"un",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN},
+    {"ua",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA}
+};
+
+const map<string, sai_my_sid_entry_endpoint_behavior_flavor_t> end_flavor_map =
+{
+    {"end",                SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"end.x",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"end.t",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"un",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"ua",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD}
+};
+
 void Srv6Orch::srv6TunnelUpdateNexthops(const string srv6_source, const NextHopKey nhkey, bool insert)
 {
     if (insert)
@@ -372,62 +404,18 @@ bool Srv6Orch::mySidExists(string my_sid_string)
 bool Srv6Orch::sidEntryEndpointBehavior(string action, sai_my_sid_entry_endpoint_behavior_t &end_behavior,
                                         sai_my_sid_entry_endpoint_behavior_flavor_t &end_flavor)
 {
-    if (action == "end")
+    if (end_behavior_map.find(action) == end_behavior_map.end())
     {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_E;
-        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
-    }
-    else if (action == "end.x")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_X;
-        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
-    }
-    else if (action == "end.t")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_T;
-        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
-    }
-    else if (action == "end.dx6")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6;
-    }
-    else if (action == "end.dx4")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4;
-    }
-    else if (action == "end.dt4")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4;
-    }
-    else if (action == "end.dt6")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6;
-    }
-    else if (action == "end.dt46")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46;
-    }
-    else if (action == "end.b6.encaps")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS;
-    }
-    else if (action == "end.b6.encaps.red")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS_RED;
-    }
-    else if (action == "end.b6.insert")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT;
-    }
-    else if (action == "end.b6.insert.red")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT_RED;
-    }
-    else
-    {
-        SWSS_LOG_ERROR("Invalid endpoing behavior function");
+        SWSS_LOG_ERROR("Invalid endpoint behavior function");
         return false;
     }
+    end_behavior = end_behavior_map.at(action);
+
+    if (end_flavor_map.find(action) != end_flavor_map.end())
+    {
+        end_flavor = end_flavor_map.at(action);
+    }
+
     return true;
 }
 

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1602,7 +1602,8 @@ void VNetRouteOrch::delEndpointMonitor(const string& vnet, NextHopGroupKey& next
         if (nexthop_info_[vnet].find(ip) != nexthop_info_[vnet].end()) {
             if (--nexthop_info_[vnet][ip].ref_count == 0)
             {
-                removeBfdSession(vnet, nhk, nexthop_info_[vnet][ip].monitor_addr);
+                IpAddress monitor_addr = nexthop_info_[vnet][ip].monitor_addr;
+                removeBfdSession(vnet, nhk, monitor_addr);
             }
         }
     }

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1110,13 +1110,14 @@ void VxlanTunnel::updateRemoteEndPointIpRef(const std::string remote_vtep, bool 
             it->second.ip_refcnt++;
         }
         SWSS_LOG_DEBUG("Incrementing remote end point %s reference to %d", remote_vtep.c_str(),
-                       it->second.ip_refcnt);
+                       tnl_users_[remote_vtep].ip_refcnt);
     }
     else
     {
         if (it == tnl_users_.end())
         {
             SWSS_LOG_ERROR("Cannot decrement ref. End point not referenced %s", remote_vtep.c_str());
+            return;
         }
         it->second.ip_refcnt--;
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,11 @@ def pytest_addoption(parser):
                      default="traditional",
                      help="Buffer model")
 
+    parser.addoption("--graceful-stop",
+                     action="store_true",
+                     default=False,
+                     help="Stop swss before stopping a conatainer")
+
 
 def random_string(size=4, chars=string.ascii_uppercase + string.digits):
     return "".join(random.choice(chars) for x in range(size))
@@ -1730,6 +1735,8 @@ def manage_dvs(request) -> str:
     max_cpu = request.config.getoption("--max_cpu")
     buffer_model = request.config.getoption("--buffer_model")
     force_recreate = request.config.getoption("--force-recreate-dvs")
+    graceful_stop = request.config.getoption("--graceful-stop")
+
     dvs = None
     curr_dvs_env = [] # lgtm[py/unused-local-variable]
 
@@ -1778,6 +1785,8 @@ def manage_dvs(request) -> str:
 
     yield update_dvs
 
+    if graceful_stop:
+        dvs.stop_swss()
     dvs.get_logs()
     dvs.destroy()
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -31,6 +31,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 copporch_ut.cpp \
                 saispy_ut.cpp \
                 consumer_ut.cpp \
+                sfloworh_ut.cpp \
                 ut_saihelper.cpp \
                 mock_orchagent_main.cpp \
                 mock_dbconnector.cpp \

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -82,3 +82,4 @@ extern sai_queue_api_t *sai_queue_api;
 extern sai_udf_api_t* sai_udf_api;
 extern sai_mpls_api_t* sai_mpls_api;
 extern sai_counter_api_t* sai_counter_api;
+extern sai_samplepacket_api_t *sai_samplepacket_api;

--- a/tests/mock_tests/portal.h
+++ b/tests/mock_tests/portal.h
@@ -6,6 +6,7 @@
 #include "aclorch.h"
 #include "crmorch.h"
 #include "copporch.h"
+#include "sfloworch.h"
 #include "directory.h"
 
 #undef protected
@@ -79,6 +80,24 @@ struct Portal
             std::vector<sai_hostif_trap_type_t> trapIdList;
             obj.getTrapIdsFromTrapGroup(trapGroupOid, trapIdList);
             return trapIdList;
+        }
+    };
+
+    struct SflowOrchInternal
+    {
+        static bool getSflowStatusEnable(SflowOrch &obj)
+        {
+            return obj.m_sflowStatus;
+        }
+
+        static SflowRateSampleMap getSflowSampleMap(SflowOrch &obj)
+        {
+            return obj.m_sflowRateSampleMap;
+        }
+
+        static SflowPortInfoMap getSflowPortInfoMap(SflowOrch &obj)
+        {
+            return obj.m_sflowPortInfoMap;
         }
     };
 

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -64,13 +64,14 @@ namespace portsorch_test
 
             ASSERT_EQ(gPortsOrch, nullptr);
 
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
+
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
             gDirectory.set(flexCounterOrch);
 
-            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
             vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
                                              APP_BUFFER_PROFILE_TABLE_NAME,
                                              APP_BUFFER_QUEUE_TABLE_NAME,
@@ -578,7 +579,7 @@ namespace portsorch_test
     * updated to DB.
     */
     TEST_F(PortsOrchTest, PortOperStatusIsUpAndOperSpeedIsZero)
-    {   
+    {
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
 
         // Get SAI default ports to populate DB
@@ -603,7 +604,7 @@ namespace portsorch_test
         Port port;
         gPortsOrch->getPort("Ethernet0", port);
         ASSERT_TRUE(port.m_oper_status != SAI_PORT_OPER_STATUS_UP);
-        
+
         // save original api since we will spy
         auto orig_port_api = sai_port_api;
         sai_port_api = new sai_port_api_t();
@@ -621,14 +622,14 @@ namespace portsorch_test
                     // Return 0 for port operational speed
                     attrs[0].value.u32 = 0;
                 }
-                
+
                 return (sai_status_t)SAI_STATUS_SUCCESS;
             }
         );
 
         auto exec = static_cast<Notifier *>(gPortsOrch->getExecutor("PORT_STATUS_NOTIFICATIONS"));
         auto consumer = exec->getNotificationConsumer();
-        
+
         // mock a redis reply for notification, it notifies that Ehernet0 is going to up
         mockReply = (redisReply *)calloc(sizeof(redisReply), 1);
         mockReply->type = REDIS_REPLY_ARRAY;
@@ -650,7 +651,7 @@ namespace portsorch_test
         // trigger the notification
         consumer->readData();
         gPortsOrch->doTask(*consumer);
-        mockReply = nullptr; 
+        mockReply = nullptr;
 
         gPortsOrch->getPort("Ethernet0", port);
         ASSERT_TRUE(port.m_oper_status == SAI_PORT_OPER_STATUS_UP);

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -176,14 +176,14 @@ namespace routeorch_test
                 { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
             };
 
+            ASSERT_EQ(gPortsOrch, nullptr);
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
+
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
             gDirectory.set(flexCounterOrch);
-
-            ASSERT_EQ(gPortsOrch, nullptr);
-            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
 
             static const  vector<string> route_pattern_tables = {
                 CFG_FLOW_COUNTER_ROUTE_PATTERN_TABLE_NAME,

--- a/tests/mock_tests/sfloworh_ut.cpp
+++ b/tests/mock_tests/sfloworh_ut.cpp
@@ -1,0 +1,372 @@
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+
+using namespace swss;
+
+namespace sflow_test
+{
+    class MockSflowOrch final
+    {
+    public:
+        MockSflowOrch()
+        {
+            this->appDb = std::make_shared<DBConnector>("APPL_DB", 0);
+            std::vector<string> sflow_tables = {
+                APP_SFLOW_TABLE_NAME,
+                APP_SFLOW_SESSION_TABLE_NAME,
+                APP_SFLOW_SAMPLE_RATE_TABLE_NAME
+            };
+            sflowOrch = std::make_shared<SflowOrch>(this->appDb.get(),  sflow_tables);
+        }
+        ~MockSflowOrch() = default;
+
+        void doSflowTableTask(const std::deque<KeyOpFieldsValuesTuple> &entries)
+        {
+            // ConsumerStateTable is used for APP DB
+            auto consumer = std::unique_ptr<Consumer>(new Consumer(
+                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_TABLE_NAME, 1, 1),
+                this->sflowOrch.get(), APP_SFLOW_TABLE_NAME
+            ));
+
+            consumer->addToSync(entries);
+            static_cast<Orch*>(this->sflowOrch.get())->doTask(*consumer);
+        }
+
+        void doSflowSessionTableTask(const std::deque<KeyOpFieldsValuesTuple> &entries)
+        {
+            // ConsumerStateTable is used for APP DB
+            auto consumer = std::unique_ptr<Consumer>(new Consumer(
+                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_SESSION_TABLE_NAME, 1, 1),
+                this->sflowOrch.get(), APP_SFLOW_SESSION_TABLE_NAME
+            ));
+
+            consumer->addToSync(entries);
+            static_cast<Orch*>(this->sflowOrch.get())->doTask(*consumer);
+        }
+
+        void doSflowSampleTableTask(const std::deque<KeyOpFieldsValuesTuple> &entries)
+        {
+            // ConsumerStateTable is used for APP DB
+            auto consumer = std::unique_ptr<Consumer>(new Consumer(
+                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_SAMPLE_RATE_TABLE_NAME, 1, 1),
+                this->sflowOrch.get(), APP_SFLOW_SAMPLE_RATE_TABLE_NAME
+            ));
+
+            consumer->addToSync(entries);
+            static_cast<Orch*>(this->sflowOrch.get())->doTask(*consumer);
+        }
+
+        SflowOrch& get()
+        {
+            return *sflowOrch;
+        }
+
+    private:
+        std::shared_ptr<SflowOrch> sflowOrch;
+        std::shared_ptr<DBConnector> appDb;
+    };
+
+    class SflowOrchTest : public ::testing::Test
+    {
+    public:
+        SflowOrchTest()
+        {
+            this->initDb();
+        }
+        virtual ~SflowOrchTest() = default;
+
+        void SetUp() override
+        {
+            this->initSaiApi();
+            this->initSwitch();
+            this->initOrch();
+            this->initPorts();
+        }
+
+        void TearDown() override
+        {
+            this->deinitOrch();
+            this->deinitSwitch();
+            this->deinitSaiApi();
+        }
+
+    private:
+        void initSaiApi()
+        {
+            std::map<std::string, std::string> profileMap = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00"        }
+            };
+            auto status = ut_helper::initSaiApi(profileMap);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+        }
+
+        void deinitSaiApi()
+        {
+            auto status = ut_helper::uninitSaiApi();
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+        }
+
+        void initSwitch()
+        {
+            sai_status_t status;
+            sai_attribute_t attr;
+
+            // Create switch
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+
+            status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            // Get switch source MAC address
+            attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gMacAddress = attr.value.mac;
+
+            // Get switch default virtual router ID
+            attr.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gVirtualRouterId = attr.value.oid;
+        }
+
+        void deinitSwitch()
+        {
+            // Remove switch
+            auto status = sai_switch_api->remove_switch(gSwitchId);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gSwitchId = SAI_NULL_OBJECT_ID;
+            gVirtualRouterId = SAI_NULL_OBJECT_ID;
+        }
+
+        void initOrch()
+        {
+            //
+            // SwitchOrch
+            //
+
+            TableConnector switchCapTableStateDb(this->stateDb.get(), "SWITCH_CAPABILITY");
+            TableConnector asicSensorsTableCfgDb(this->configDb.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+            TableConnector switchTableAppDb(this->appDb.get(), APP_SWITCH_TABLE_NAME);
+
+            std::vector<TableConnector> switchTableList = {
+                asicSensorsTableCfgDb,
+                switchTableAppDb
+            };
+
+            gSwitchOrch = new SwitchOrch(this->appDb.get(), switchTableList, switchCapTableStateDb);
+            gDirectory.set(gSwitchOrch);
+            resourcesList.push_back(gSwitchOrch);
+
+            //
+            // PortsOrch
+            //
+
+            const int portsorchBasePri = 40;
+
+            std::vector<table_name_with_pri_t> portTableList = {
+                { APP_PORT_TABLE_NAME,        portsorchBasePri + 5 },
+                { APP_VLAN_TABLE_NAME,        portsorchBasePri + 2 },
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorchBasePri     },
+                { APP_LAG_TABLE_NAME,         portsorchBasePri + 4 },
+                { APP_LAG_MEMBER_TABLE_NAME,  portsorchBasePri     }
+            };
+
+            gPortsOrch = new PortsOrch(this->appDb.get(), this->stateDb.get(), portTableList, this->chassisAppDb.get());
+            gDirectory.set(gPortsOrch);
+            resourcesList.push_back(gPortsOrch);
+
+            //
+            // QosOrch
+            //
+
+            std::vector<std::string> qosTableList = {
+                CFG_TC_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_SCHEDULER_TABLE_NAME,
+                CFG_DSCP_TO_TC_MAP_TABLE_NAME,
+                CFG_MPLS_TC_TO_TC_MAP_TABLE_NAME,
+                CFG_DOT1P_TO_TC_MAP_TABLE_NAME,
+                CFG_QUEUE_TABLE_NAME,
+                CFG_PORT_QOS_MAP_TABLE_NAME,
+                CFG_WRED_PROFILE_TABLE_NAME,
+                CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_DSCP_TO_FC_MAP_TABLE_NAME,
+                CFG_EXP_TO_FC_MAP_TABLE_NAME
+            };
+            gQosOrch = new QosOrch(this->configDb.get(), qosTableList);
+            gDirectory.set(gQosOrch);
+            resourcesList.push_back(gQosOrch);
+
+            //
+            // BufferOrch
+            //
+
+            std::vector<std::string> bufferTableList = {
+                APP_BUFFER_POOL_TABLE_NAME,
+                APP_BUFFER_PROFILE_TABLE_NAME,
+                APP_BUFFER_QUEUE_TABLE_NAME,
+                APP_BUFFER_PG_TABLE_NAME,
+                APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
+            };
+            gBufferOrch = new BufferOrch(this->appDb.get(), this->configDb.get(), this->stateDb.get(), bufferTableList);
+            gDirectory.set(gBufferOrch);
+            resourcesList.push_back(gBufferOrch);
+
+            //
+            // FlexCounterOrch
+            //
+
+            std::vector<std::string> flexCounterTableList = {
+                CFG_FLEX_COUNTER_TABLE_NAME
+            };
+
+            auto flexCounterOrch = new FlexCounterOrch(this->configDb.get(), flexCounterTableList);
+            gDirectory.set(flexCounterOrch);
+            resourcesList.push_back(flexCounterOrch);
+        }
+
+        void deinitOrch()
+        {
+            std::reverse(this->resourcesList.begin(), this->resourcesList.end());
+            for (auto &it : this->resourcesList)
+            {
+                delete it;
+            }
+
+            gSwitchOrch = nullptr;
+            gPortsOrch = nullptr;
+            gQosOrch = nullptr;
+            gBufferOrch = nullptr;
+
+            Portal::DirectoryInternal::clear(gDirectory);
+            EXPECT_TRUE(Portal::DirectoryInternal::empty(gDirectory));
+        }
+
+        void initPorts()
+        {
+            auto portTable = Table(this->appDb.get(), APP_PORT_TABLE_NAME);
+
+            // Get SAI default ports to populate DB
+            auto ports = ut_helper::getInitialSaiPorts();
+
+            // Populate port table with SAI ports
+            for (const auto &cit : ports)
+            {
+                portTable.set(cit.first, cit.second);
+            }
+
+            // Set PortConfigDone
+            portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch*>(gPortsOrch)->doTask();
+
+            // Set PortInitDone
+            portTable.set("PortInitDone", { { "lanes", "0" } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch*>(gPortsOrch)->doTask();
+        }
+
+        void initDb()
+        {
+            this->appDb = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            this->configDb = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            this->stateDb = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+            this->chassisAppDb = std::make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
+        }
+
+        std::shared_ptr<DBConnector> appDb;
+        std::shared_ptr<DBConnector> configDb;
+        std::shared_ptr<DBConnector> stateDb;
+        std::shared_ptr<DBConnector> chassisAppDb;
+
+        std::vector<Orch*> resourcesList;
+    };
+
+    /* Test enabling/disabling SFLOW */
+    TEST_F(SflowOrchTest, SflowEnableDisable)
+    {
+        MockSflowOrch mock_orch;
+        {
+            auto table1 = deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        "global",
+                        SET_COMMAND,
+                        {
+                            {"admin_state", "down"}
+                        }
+                    }
+                });
+            mock_orch.doSflowTableTask(table1);
+
+            ASSERT_FALSE(Portal::SflowOrchInternal::getSflowStatusEnable(mock_orch.get()));
+        }
+        {
+            auto table2 = deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        "global",
+                        SET_COMMAND,
+                        {
+                            {"admin_state", "up"}
+                        }
+                    }
+                });
+            mock_orch.doSflowTableTask(table2);
+
+            ASSERT_TRUE(Portal::SflowOrchInternal::getSflowStatusEnable(mock_orch.get()));
+        }
+    }
+
+    /* Test create/delete SFLOW */
+    TEST_F(SflowOrchTest, SflowCreateDelete)
+    {
+        MockSflowOrch mock_orch;
+        {
+            auto table3 = deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        "global",
+                        SET_COMMAND,
+                        {
+                            {"admin_state", "up"},
+                        }
+                    }
+                });
+            mock_orch.doSflowTableTask(table3);
+            ASSERT_TRUE(Portal::SflowOrchInternal::getSflowStatusEnable(mock_orch.get()));
+        }
+        {
+            auto table4 = deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        "global",
+                        DEL_COMMAND,
+                        {
+                            {"admin_state", "up"},
+                        }
+                    }
+                });
+            mock_orch.doSflowTableTask(table4);
+            ASSERT_FALSE(Portal::SflowOrchInternal::getSflowStatusEnable(mock_orch.get()));
+        }
+    }
+}
+
+

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -66,6 +66,7 @@ namespace ut_helper
         sai_api_query(SAI_API_SWITCH, (void **)&sai_switch_api);
         sai_api_query(SAI_API_BRIDGE, (void **)&sai_bridge_api);
         sai_api_query(SAI_API_VIRTUAL_ROUTER, (void **)&sai_virtual_router_api);
+        sai_api_query(SAI_API_SAMPLEPACKET, (void **)&sai_samplepacket_api);
         sai_api_query(SAI_API_PORT, (void **)&sai_port_api);
         sai_api_query(SAI_API_LAG, (void **)&sai_lag_api);
         sai_api_query(SAI_API_VLAN, (void **)&sai_vlan_api);

--- a/tests/test_buffer_traditional.py
+++ b/tests/test_buffer_traditional.py
@@ -77,12 +77,14 @@ class TestBuffer(object):
 
     @pytest.fixture
     def setup_teardown_test(self, dvs):
-        try:
-            self.setup_db(dvs)
-            self.set_port_qos_table(self.INTF, '3,4')
-            self.lossless_pg_combinations = ['3-4']
-        finally:
-            self.teardown()
+        self.setup_db(dvs)
+        self.set_port_qos_table(self.INTF, '3,4')
+        self.lossless_pg_combinations = ['3-4']
+        time.sleep(2)
+
+        yield
+
+        self.teardown()
 
     def test_zero_cable_len_profile_update(self, dvs, setup_teardown_test):
         orig_cable_len = None

--- a/tests/test_flex_counters.py
+++ b/tests/test_flex_counters.py
@@ -7,8 +7,6 @@ TUNNEL_TYPE_MAP           = "COUNTERS_TUNNEL_TYPE_MAP"
 ROUTE_TO_PATTERN_MAP      = "COUNTERS_ROUTE_TO_PATTERN_MAP"
 NUMBER_OF_RETRIES         = 10
 CPU_PORT_OID              = "0x0"
-PORT                      = "Ethernet0"
-PORT_MAP                  = "COUNTERS_PORT_NAME_MAP"
 
 counter_group_meta = {
     'port_counter': {
@@ -73,7 +71,6 @@ counter_group_meta = {
     }
 }
 
-@pytest.mark.usefixtures('dvs_port_manager')
 class TestFlexCounters(object):
 
     def setup_dbs(self, dvs):
@@ -132,6 +129,18 @@ class TestFlexCounters(object):
                 time.sleep(1)
 
         assert False, "Polling interval is not applied to FLEX_COUNTER_GROUP_TABLE for group {}, expect={}, actual={}".format(group, interval, interval_value)
+
+    def wait_for_buffer_pg_queue_counter(self, map, port, index, isSet):
+        for retry in range(NUMBER_OF_RETRIES):
+            counter_oid = self.counters_db.db_connection.hget(map, port + ':' + index)
+            if (isSet and counter_oid):
+                return counter_oid
+            elif (not isSet and not counter_oid):
+                return None
+            else:
+                time.sleep(1)
+
+        assert False, "Counter not {} for port: {}, type: {}, index: {}".format("created" if isSet else "removed", port, map, index)
 
     def verify_no_flex_counters_tables(self, counter_stat):
         counters_stat_keys = self.flex_db.get_keys("FLEX_COUNTER_TABLE:" + counter_stat)
@@ -692,64 +701,53 @@ class TestFlexCounters(object):
 
     def set_admin_status(self, interface, status):
         self.config_db.update_entry("PORT", interface, {"admin_status": status})
-            
-    def test_add_remove_ports(self, dvs):
+
+    def test_create_remove_buffer_pg_counter(self, dvs):
+        """
+        Test steps:
+            1. Enable PG flex counters.
+            2. Configure new buffer prioriy group for a port
+            3. Verify counter is automatically created
+            4. Remove the new buffer prioriy group for the port
+            5. Verify counter is automatically removed
+
+        Args:
+            dvs (object): virtual switch object
+        """
         self.setup_dbs(dvs)
-        
-        # set flex counter
-        counter_key = counter_group_meta['queue_counter']['key']
-        counter_stat = counter_group_meta['queue_counter']['group_name']
-        counter_map = counter_group_meta['queue_counter']['name_map']
-        self.set_flex_counter_group_status(counter_key, counter_map)
+        meta_data = counter_group_meta['pg_watermark_counter']
 
-        # receive port info
-        fvs = self.config_db.get_entry("PORT", PORT)
-        assert len(fvs) > 0
-        
-        # save all the oids of the pg drop counters            
-        oid_list = []
-        counters_queue_map = self.counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
-        for key, oid in counters_queue_map.items():
-            if PORT in key:
-                oid_list.append(oid)
-                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", counter_stat + ":%s" % oid)
-                assert len(fields) == 1
-        oid_list_len = len(oid_list)
+        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
 
-        # get port oid
-        port_oid = self.counters_db.get_entry(PORT_MAP, "")[PORT]
+        self.config_db.update_entry('BUFFER_PG', 'Ethernet0|1', {'profile': 'ingress_lossy_profile'})
+        counter_oid = self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '1', True)
+        self.wait_for_id_list(meta_data['group_name'], "Ethernet0", counter_oid)
 
-        # remove port and verify that it was removed properly
-        self.dvs_port.remove_port(PORT)
-        dvs.get_asic_db().wait_for_deleted_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
-        
-        # verify counters were removed from flex counter table
-        for oid in oid_list:
-            fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", counter_stat + ":%s" % oid)
-            assert len(fields) == 0
-        
-        # verify that port counter maps were removed from counters db
-        counters_queue_map = self.counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
-        for key in counters_queue_map.keys():
-            if PORT in key:
-                assert False
-        
-        # add port and wait until the port is added on asic db
-        num_of_keys_without_port = len(dvs.get_asic_db().get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))
-        
-        self.config_db.create_entry("PORT", PORT, fvs)
-        
-        dvs.get_asic_db().wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT", num_of_keys_without_port + 1)
-        dvs.get_counters_db().wait_for_fields("COUNTERS_QUEUE_NAME_MAP", "", ["%s:0"%(PORT)])
-        
-        # verify queue counters were added
-        oid_list = []
-        counters_queue_map = self.counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
+        self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|1')
+        self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '1', False)
+        self.wait_for_id_list_remove(meta_data['group_name'], "Ethernet0", counter_oid)
 
-        for key, oid in counters_queue_map.items():
-            if PORT in key:
-                oid_list.append(oid)
-                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", counter_stat + ":%s" % oid)
-                assert len(fields) == 1
-        # the number of the oids needs to be the same as the original number of oids (before removing a port and adding)
-        assert oid_list_len == len(oid_list)
+    def test_create_remove_buffer_queue_counter(self, dvs):
+        """
+        Test steps:
+            1. Enable Queue flex counters.
+            2. Configure new buffer queue for a port
+            3. Verify counter is automatically created
+            4. Remove the new buffer queue for the port
+            5. Verify counter is automatically removed
+
+        Args:
+            dvs (object): virtual switch object
+        """
+        self.setup_dbs(dvs)
+        meta_data = counter_group_meta['queue_counter']
+
+        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
+
+        self.config_db.update_entry('BUFFER_QUEUE', 'Ethernet0|7', {'profile': 'egress_lossless_profile'})
+        counter_oid = self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '7', True)
+        self.wait_for_id_list(meta_data['group_name'], "Ethernet0", counter_oid)
+
+        self.config_db.delete_entry('BUFFER_QUEUE', 'Ethernet0|7')
+        self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '7', False)
+        self.wait_for_id_list_remove(meta_data['group_name'], "Ethernet0", counter_oid)

--- a/tests/test_srv6.py
+++ b/tests/test_srv6.py
@@ -56,6 +56,7 @@ class TestSrv6Mysid(object):
         # create MySID entries
         mysid1='16:8:8:8:baba:2001:10::'
         mysid2='16:8:8:8:baba:2001:20::'
+        mysid3='16:8:8:8:fcbb:bb01:800::'
 
         # create MySID END
         fvs = swsscommon.FieldValuePairs([('action', 'end')])
@@ -90,13 +91,29 @@ class TestSrv6Mysid(object):
             elif fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
                 assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46"
 
+        # create MySID uN
+        fvs = swsscommon.FieldValuePairs([('action', 'un')])
+        key = self.create_mysid(mysid3, fvs)
+
+        # check ASIC MySID database
+        mysid = json.loads(key)
+        assert mysid["sid"] == "fcbb:bb01:800::"
+        tbl = swsscommon.Table(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY")
+        (status, fvs) = tbl.get(key)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN"
+            elif fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR":
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD"
+
         # delete MySID
         self.remove_mysid(mysid1)
         self.remove_mysid(mysid2)
+        self.remove_mysid(mysid3)
 
         # remove vrf
         self.remove_vrf("VrfDt46")
-
 
 class TestSrv6(object):
     def setup_db(self, dvs):

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -104,22 +104,8 @@ class TestWatermark(object):
             assert found, "no such watermark found"
 
     def set_up_flex_counter(self, dvs):
-        for q in self.qs:
-            self.flex_db.create_entry("FLEX_COUNTER_TABLE",
-                                     "QUEUE_WATERMARK_STAT_COUNTER:{}".format(q),
-                                     WmFCEntry.queue_stats_entry)
-
-        for pg in self.pgs:
-            self.flex_db.create_entry("FLEX_COUNTER_TABLE",
-                                     "PG_WATERMARK_STAT_COUNTER:{}".format(pg),
-                                     WmFCEntry.pg_stats_entry)
-
-        for buffer in self.buffers:
-            self.flex_db.create_entry("FLEX_COUNTER_TABLE",
-                                      "BUFFER_POOL_WATERMARK_STAT_COUNTER:{}".format(buffer),
-                                      WmFCEntry.buffer_stats_entry)
-
         fc_status_enable = {"FLEX_COUNTER_STATUS": "enable"}
+
         self.config_db.create_entry("FLEX_COUNTER_TABLE",
                                     "PG_WATERMARK",
                                     fc_status_enable)
@@ -130,7 +116,8 @@ class TestWatermark(object):
                                     "BUFFER_POOL_WATERMARK",
                                     fc_status_enable)
 
-        self.populate_asic_all(dvs, "0")
+        # Wait for DB's to populate by orchagent
+        time.sleep(2)
 
     def clear_flex_counter(self, dvs):
         for q in self.qs:
@@ -150,9 +137,13 @@ class TestWatermark(object):
         self.config_db.delete_entry("FLEX_COUNTER_TABLE", "BUFFER_POOL_WATERMARK")
 
     def set_up(self, dvs):
-        self.qs = self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_QUEUE")
-        self.pgs = self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP")
+        self.pgs = self.counters_db.db_connection.hgetall("COUNTERS_PG_NAME_MAP").values()
+        assert self.pgs is not None and len(self.pgs) > 0
+        self.qs = self.counters_db.db_connection.hgetall("COUNTERS_QUEUE_NAME_MAP").values()
+        assert self.qs is not None and len(self.pgs) > 0
         self.buffers = self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL")
+
+        self.populate_asic_all(dvs, "0")
 
         db = swsscommon.DBConnector(swsscommon.COUNTERS_DB, dvs.redis_sock, 0)
         tbl = swsscommon.Table(db, "COUNTERS_QUEUE_TYPE_MAP")
@@ -180,9 +171,9 @@ class TestWatermark(object):
 
     def test_telemetry_period(self, dvs):
         self.setup_dbs(dvs)
+        self.set_up_flex_counter(dvs)
         self.set_up(dvs)
         try:
-            self.set_up_flex_counter(dvs)
             self.enable_unittests(dvs, "true")
 
             self.populate_asic_all(dvs, "100")


### PR DESCRIPTION
Author: Shlomi Bitton <shlomibi@nvidia.com>
Date:   Sun Jan 2 16:55:58 2022 +0000

    Filter unconfigured ports buffers queue/pg counters configurations on init.
    If no buffer configurations available, no counters will be created.
    Allow creating/removing counters on runtime if buffer PG/Queue is created or removed.
    New UT added to verify new flow.

    Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
